### PR TITLE
docs: add README and Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_NAME=nodo
+DB_USER=nodo
+DB_PASS=nodo_pass
+DB_HOST=localhost
+DB_PORT=3306
+DJANGO_SECRET=changeme

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Nodo Monorepo
+
+Este repositorio centraliza el código del backend y frontend del proyecto. Cada módulo vive en su propio directorio para facilitar el desarrollo y el despliegue.
+
+## Requisitos
+- Docker y docker-compose
+- Python 3 y pip
+- Node.js y npm
+
+## Inicio rápido
+1. Copia `.env.example` a `.env` y ajusta las variables según tu entorno.
+2. Levanta las dependencias con `docker-compose up -d`.
+3. Ejecuta los servicios del backend y frontend según corresponda.
+
+## Estructura
+- `backend/`: código de la API y lógica de negocio.
+- `frontend/`: aplicación cliente.
+- `dbdata/`: datos persistentes de MySQL.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  mysql:
+    image: mysql:8
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+      MYSQL_ROOT_PASSWORD: ${DB_PASS}
+    ports:
+      - "${DB_PORT:-3306}:3306"
+    volumes:
+      - ./dbdata:/var/lib/mysql
+  adminer:
+    image: adminer
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql


### PR DESCRIPTION
## Summary
- document monorepo structure and startup steps in README
- add environment variable example
- include docker-compose for MySQL and Adminer

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c22258eca8832d8e24d04c97ee83ae