### PR TITLE
Add frontend Dockerfile and compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,8 @@ services:
       - "8080:8080"
     depends_on:
       - mysql
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    env_file: .env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18
+WORKDIR /app
+COPY . .
+RUN npm install
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- add Node 18 Dockerfile for frontend
- configure frontend service in docker-compose

## Testing
- `docker compose up --build frontend` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd8e91cc832d8ca8cbff842cdd22