### PR TITLE
Add backend service Dockerfile and compose config

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements/base.txt
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
       - "${DB_PORT:-3306}:3306"
     volumes:
       - ./dbdata:/var/lib/mysql
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    env_file: .env
+    depends_on:
+      - mysql
   adminer:
     image: adminer
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add backend service definition to docker-compose
- add Dockerfile for backend app

## Testing
- `docker-compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd8b79a0832da77355d6b6b79c45