### PR TITLE
feat: install build dependencies in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY . /app
+RUN apt-get update \
+    && apt-get install -y build-essential default-libmysqlclient-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements/base.txt
 
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary
- install build-essential and default-libmysqlclient-dev before Python dependencies

## Testing
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68c2c4bc6c88832dafd9862d1a778a3b