### PR TITLE
Add NEXT_PUBLIC_API_URL to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ DB_NAME=nodo
 DB_USER=nodo
 DB_PASS=nodo_pass
 DB_HOST=localhost
+# En Docker este valor debe ser `mysql`
 DB_PORT=3306
-DJANGO_SECRET=changeme
+DJANGO_SECRET_KEY=changeme
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ DB_PASS=nodo_pass
 DB_HOST=localhost
 DB_PORT=3306
 DJANGO_SECRET=changeme
+NEXT_PUBLIC_API_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_API_URL to env example file for frontend configuration

## Testing
- `pytest`
- `npm test` *(fails: npm not installed; apt repositories unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c4bd6dac832d963de9c8e87613ab