### PR TITLE
Document migration step and Docker backend URL for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,16 @@ Este repositorio centraliza el código del backend y frontend del proyecto. Cada
    ```bash
    docker-compose up --build -d
    ```
-3. Accede a los servicios:
+3. Aplica las migraciones de la base de datos:
+   ```bash
+   docker-compose exec backend python manage.py migrate
+   ```
+4. Accede a los servicios:
    - Backend: http://localhost:8000
    - Frontend: http://localhost:3000
    - Adminer: http://localhost:8080
-4. Ejecuta los servicios del backend y frontend según corresponda.
+   - **Nota:** si el frontend se ejecuta dentro de Docker, su URL de API debe apuntar a `http://backend:8000`.
+5. Ejecuta los servicios del backend y frontend según corresponda.
 
 ## Estructura
 - `backend/`: código de la API y lógica de negocio.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_URL=http://localhost:3000/api
+NEXT_PUBLIC_API_URL=http://backend:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,1 +1,3 @@
 Placeholder frontend directory for Next.js project.
+
+When running inside Docker, configure the API URL to use the backend service at `http://backend:8000`.


### PR DESCRIPTION
## Summary
- document running Django migrations after starting containers
- note frontend should use `http://backend:8000` inside Docker

## Testing
- `npm test`
- `python -m py_compile backend/manage.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68c2c4bec024832d8bccc322687a6b12