### PR TITLE
docs: add technologies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Este repositorio centraliza el código del backend y frontend del proyecto. Cada
 - `frontend/`: aplicación cliente.
 - `dbdata/`: datos persistentes de MySQL.
 
+## Tecnologías
+- **Django + DRF**: API backend y administración de autenticación.
+- **MySQL**: Base de datos relacional.
+- **Next.js (React)**: Frontend con renderizado del lado del servidor.
+- **TailwindCSS**: Estilado del frontend.
+- **Docker + docker-compose**: Orquestación de servicios y dependencias.
+
 ## Mantenimiento
 - Reinicia los contenedores para aplicar cambios con:
   ```bash


### PR DESCRIPTION
## Summary
- document tech stack in README

## Testing
- `pip install -r backend/requirements/base.txt` *(fails: Could not find a version that satisfies the requirement Django)*
- `DB_NAME=test DB_USER=user DB_PASS=pass DB_HOST=localhost DB_PORT=3306 python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2caaef170832d9984e035c0338fcb