### PR TITLE
Add pkg-config to backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY . /app
 RUN apt-get update \
-    && apt-get install -y build-essential default-libmysqlclient-dev \
+    && apt-get install -y build-essential default-libmysqlclient-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements/base.txt
 


### PR DESCRIPTION
## Summary
- include pkg-config in backend Dockerfile's build dependencies

## Testing
- `docker-compose up --build` *(fails: command not found)*
- `docker compose up --build` *(fails: command not found)*
- `apt-get install -y docker.io` *(fails: Unable to locate package docker.io)*

------
https://chatgpt.com/codex/tasks/task_e_68c2caff5f08832d897509e9b1d8e27f