### PR TITLE
chore: change MySQL port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       MYSQL_PASSWORD: ${DB_PASS}
       MYSQL_ROOT_PASSWORD: ${DB_PASS}
     ports:
-      - "${DB_PORT:-3306}:3306"
+      - "3307:3306"
     volumes:
       - ./dbdata:/var/lib/mysql
   backend:


### PR DESCRIPTION
## Summary
- map MySQL service to host port 3307

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('docker-compose.yml'); puts 'YAML ok'"`


------
https://chatgpt.com/codex/tasks/task_e_68c2cd8b3a8c832daded82220431a36c