### PR TITLE
Add backend entrypoint and compose configuration

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,9 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY . /app
+COPY entrypoint.sh /app/
 RUN apt-get update \
     && apt-get install -y build-essential default-libmysqlclient-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements/base.txt
+RUN chmod +x /app/entrypoint.sh
 
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+python manage.py makemigrations --noinput
+python manage.py migrate --noinput
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./dbdata:/var/lib/mysql
   backend:
     build: ./backend
+    entrypoint: ["/app/entrypoint.sh", "python", "manage.py", "runserver", "0.0.0.0:8000"]
     ports:
       - "8000:8000"
     env_file: .env


### PR DESCRIPTION
## Summary
- add backend entrypoint script to run migrations
- copy entrypoint in Dockerfile and mark executable
- configure docker-compose backend to use new entrypoint

## Testing
- `sh -n backend/entrypoint.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cd7c0414832dbcf0235760d60aab