### PR TITLE
Remove docker compose version field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   mysql:
     image: mysql:8


### PR DESCRIPTION
## Summary
- remove explicit version from docker-compose configuration

## Testing
- `docker-compose up --build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c2cd7ebe44832d92a93a70312fccc1