### PR TITLE
Remove MySQL user env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 DB_NAME=nodo
-DB_USER=root
-DB_PASS=root
+DB_USER=nodo_user
+DB_PASS=nodo_pass
 DB_HOST=127.0.0.1
 # En Docker este valor debe ser `mysql`
 DB_PORT=3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_USER: ${DB_USER}
-      MYSQL_PASSWORD: ${DB_PASS}
       MYSQL_ROOT_PASSWORD: ${DB_PASS}
     ports:
       - "3307:3306"


### PR DESCRIPTION
## Summary
- remove MYSQL_USER and MYSQL_PASSWORD from docker-compose
- set non-root DB_USER and DB_PASS in .env

## Testing
- `docker-compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e3af8f34832db39481dc6f438d0b