### PR TITLE
Separate backend entrypoint from start command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
       - ./dbdata:/var/lib/mysql
   backend:
     build: ./backend
-    entrypoint: ["/app/entrypoint.sh", "python", "manage.py", "runserver", "0.0.0.0:8000"]
+    entrypoint: ["/app/entrypoint.sh"]
+    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
     ports:
       - "8000:8000"
     env_file: .env


### PR DESCRIPTION
## Summary
- point backend container entrypoint to the script and move Django run command to `command`

## Testing
- `docker-compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f7746d70832dbb3a14e226b19a95