### PR TITLE
Allow configurable frontend URL for CORS

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,5 @@ DB_PORT=3306
 
 # URL base del backend para el frontend
 NEXT_PUBLIC_API_URL=http://backend:8000
+
+FRONTEND_URL=http://localhost:3008

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -89,6 +89,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOWED_ORIGINS = [
     'http://localhost:3000',
+    os.getenv('FRONTEND_URL', 'http://localhost:3008'),
 ]
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
## Summary
- allow overriding frontend origin via `FRONTEND_URL` env with default `http://localhost:3008`
- document default frontend URL in `.env`

## Testing
- `python backend/manage.py test` *(fails: No module named 'django')*
- `docker compose up -d --build backend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fdb1b82c832d8e8e7f3b2af522e2