### PR TITLE
chore: set API URL to localhost

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ DB_HOST=mysql
 DB_PORT=3306
 
 # URL base del backend para el frontend
-NEXT_PUBLIC_API_URL=http://backend:8000
+NEXT_PUBLIC_API_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- point frontend to backend via localhost API URL

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `docker compose build frontend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fd869418832d8473224ba7ca76f2