### PR TITLE
Fix backend entrypoint and MySQL volume

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY . /app
-COPY entrypoint.sh /app/
 RUN apt-get update \
     && apt-get install -y build-essential default-libmysqlclient-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements/base.txt
 RUN chmod +x /app/entrypoint.sh
 
+ENTRYPOINT ["sh", "/app/entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,9 @@ services:
     ports:
       - "3308:3306"
     volumes:
-      - ./dbdata:/var/lib/mysql
+      - db_data:/var/lib/mysql
   backend:
     build: ./backend
-    entrypoint: ["/app/entrypoint.sh"]
     command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
     ports:
       - "8000:8000"
@@ -30,3 +29,6 @@ services:
     ports:
       - "3008:3000"
     env_file: .env
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- configure backend container to run entrypoint script via Dockerfile
- switch MySQL to named volume to avoid host directory issues

## Testing
- `python -m py_compile backend/manage.py`


------
https://chatgpt.com/codex/tasks/task_e_68c30047f054832db4d05c6b79ca0788