### PR TITLE
chore: drop compose version header

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   mysql:
     image: mysql:8


### PR DESCRIPTION
## Summary
- remove deprecated `version` declaration from docker-compose.yml

## Testing
- `docker compose up --build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c30ab758b8832d8cf6a390a3fa7924