### PR TITLE
chore: speed up frontend startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
   frontend:
     build: ./frontend
     env_file: .env
-    command: sh -c "npm ci && npm run dev -- -p 3000 -H 0.0.0.0"
+    command: npm run dev -- -p 3000 -H 0.0.0.0
     ports:
       - "3008:3000"
 


### PR DESCRIPTION
## Summary
- reuse already-installed dependencies in frontend docker container by invoking dev server directly

## Testing
- `docker compose build frontend` *(fails: command not found: docker)*
- `docker compose up frontend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c41339e4a8832dbf648430bcc3f70a