### PR TITLE
Use gunicorn for backend server

### DIFF
--- a/backend/requirements/base.lock
+++ b/backend/requirements/base.lock
@@ -1,0 +1,9 @@
+Django==5.0.6
+djangorestframework==3.15.1
+djangorestframework-simplejwt==5.3.1
+drf-spectacular==0.27.0
+django-filter==24.3
+django-cors-headers==4.4.0
+mysqlclient==2.2.4
+python-dotenv==1.0.1
+gunicorn==21.2.0

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -6,3 +6,4 @@ django-filter
 django-cors-headers
 mysqlclient
 python-dotenv
+gunicorn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       sh -c "
       python manage.py migrate --no-input &&
       python manage.py collectstatic --no-input --clear --no-post-process || true &&
-      python manage.py runserver 0.0.0.0:8000
+      gunicorn config.wsgi:application --bind 0.0.0.0:8000
       "
     ports:
       - "8000:8000"


### PR DESCRIPTION
## Summary
- add gunicorn to backend requirements and record pinned versions
- serve backend through gunicorn in docker-compose

## Testing
- `python backend/manage.py check` *(fails: No module named 'django')*
- `docker compose build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4133b026c832d85b0256f6a07baf8