### PR TITLE
feat: add legajo template builder and renderer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,21 +10,28 @@
     "test": "echo \"No tests specified\""
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.0.6",
+    "@dnd-kit/modifiers": "^6.0.6",
+    "@dnd-kit/sortable": "^6.0.6",
     "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.32.1",
+    "clsx": "^2.0.0",
+    "flowbite": "^2.3.0",
+    "nanoid": "^5.0.5",
+    "react-grid-layout": "^1.3.4",
     "react-hook-form": "^7.50.0",
     "zod": "^3.22.4",
-    "flowbite": "^2.3.0"
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
-    "next": "14.x",
-    "react": "18.x",
-    "react-dom": "18.x",
     "@types/node": "^20.11.19",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "autoprefixer": "^10.4.16",
+    "next": "14.x",
     "postcss": "^8.4.31",
+    "react": "18.x",
+    "react-dom": "18.x",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   }

--- a/frontend/src/app/legajos/[id]/page.tsx
+++ b/frontend/src/app/legajos/[id]/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { repo } from "@/lib/legajos/repo";
+import DynamicForm from "@/lib/legajos/renderer/Renderer";
+import { useClientGuard } from "@/lib/useClientGuard";
+
+export default function LegajoDetail() {
+  useClientGuard();
+  const { id } = useParams<{id:string}>();
+  const [d,setD] = useState<any>(null);
+  const [t,setT] = useState<any>(null);
+
+  useEffect(()=>{ (async()=>{
+    const dossier = await repo.getDossier(id); setD(dossier);
+    if (dossier) setT(await repo.getTemplate(dossier.templateId));
+  })(); },[id]);
+
+  if (!d || !t) return <main className="p-6 text-white">Cargando…</main>;
+
+  return (
+    <main className="p-6 text-white">
+      <h1 className="text-xl font-semibold mb-3">Legajo · {t.name}</h1>
+      <DynamicForm template={t} defaultValues={d.data} onSubmit={async (v)=>{
+        await repo.saveDossier({ ...d, data: v }); alert("Guardado");
+      }}/>
+    </main>
+  );
+}

--- a/frontend/src/app/legajos/nuevo/page.tsx
+++ b/frontend/src/app/legajos/nuevo/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { repo } from "@/lib/legajos/repo";
+import DynamicForm from "@/lib/legajos/renderer/Renderer";
+import { useClientGuard } from "@/lib/useClientGuard";
+
+export default function NuevoLegajo() {
+  useClientGuard();
+  const sp = useSearchParams(); const r = useRouter();
+  const [template,setTemplate] = useState<any>(null);
+
+  useEffect(()=>{ (async()=>{
+    const id = sp.get("plantilla");
+    if (!id) return;
+    const t = await repo.getTemplate(id);
+    setTemplate(t ?? null);
+  })(); },[sp]);
+
+  if (!template) return <main className="p-6 text-white">Cargando plantilla…</main>;
+
+  return (
+    <main className="p-6 text-white">
+      <h1 className="text-xl font-semibold mb-3">Nuevo legajo · {template.name}</h1>
+      <DynamicForm template={template} onSubmit={async (v)=>{
+        const d = await repo.createDossier({ templateId: template.id, templateVersion: template.version, data: v, status:"active" });
+        r.replace(`/legajos/${d.id}`);
+      }}/>
+    </main>
+  );
+}

--- a/frontend/src/app/legajos/page.tsx
+++ b/frontend/src/app/legajos/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { repo } from "@/lib/legajos/repo";
+import { Dossier } from "@/lib/legajos/schema";
+import { useClientGuard } from "@/lib/useClientGuard";
+
+export default function LegajosList() {
+  useClientGuard();
+  const [items,setItems] = useState<Dossier[]>([]);
+  useEffect(()=>{ repo.listDossiers().then(setItems); },[]);
+  return (
+    <main className="p-6 text-white">
+      <h1 className="text-2xl font-semibold mb-4">Legajos</h1>
+      <ul className="space-y-2">
+        {items.map(d=>(
+          <li key={d.id} className="border border-gray-800 rounded-xl p-3 flex items-center justify-between">
+            <div>
+              <div className="font-medium">{d.id}</div>
+              <div className="text-xs text-gray-400">{d.templateId} · v{d.templateVersion} · {d.status}</div>
+            </div>
+            <Link href={`/legajos/${d.id}`} className="px-3 py-1 rounded-lg bg-gray-800">Abrir</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/app/plantillas/[id]/builder/page.tsx
+++ b/frontend/src/app/plantillas/[id]/builder/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useBuilder } from "@/lib/legajos/builder/store";
+import { repo } from "@/lib/legajos/repo";
+import DynamicForm from "@/lib/legajos/renderer/Renderer";
+import { FieldDef } from "@/lib/legajos/schema";
+import { useRouter, useParams } from "next/navigation";
+import { useClientGuard } from "@/lib/useClientGuard";
+
+const FIELD_TYPES: {type: FieldDef["type"]; label: string}[] = [
+  { type:"text", label:"Texto" },
+  { type:"number", label:"Número" },
+  { type:"date", label:"Fecha" },
+  { type:"select", label:"Select" },
+  { type:"textarea", label:"Área de texto" },
+  { type:"boolean", label:"Booleano" },
+];
+
+export default function BuilderPage() {
+  useClientGuard();
+  const r = useRouter();
+  const params = useParams();
+  const { template, setTemplate, addField, addFieldToLayout, updateField } = useBuilder();
+  const [preview, setPreview] = useState(false);
+
+  // cargar plantilla si existe
+  useEffect(()=>{ (async()=>{
+    const id = params?.id as string;
+    const t = await repo.getTemplate(id);
+    if (t) setTemplate(t);
+  })(); },[params,setTemplate]);
+
+  const add = (t: FieldDef["type"]) => {
+    const f = addField(t);
+    // por simplicidad: agregar al primer col
+    addFieldToLayout(f.key, [0,0]);
+  };
+
+  const save = async () => { await repo.upsertTemplate(template); alert("Plantilla guardada"); };
+  const publish = async () => { await repo.publishTemplate(template.id); setTemplate({ ...template, status:"published" }); alert("Publicada"); };
+
+  return (
+    <div className="min-h-screen grid grid-cols-12 bg-gray-900 text-white">
+      {/* Paleta izquierda */}
+      <aside className="col-span-2 border-r border-gray-800 p-3">
+        <h3 className="font-semibold mb-2">Bloques</h3>
+        <div className="space-y-2">
+          {FIELD_TYPES.map(ft=>(
+            <button key={ft.type} onClick={()=>add(ft.type)} className="w-full bg-gray-800 hover:bg-gray-700 rounded-lg px-3 py-2 text-left">{ft.label}</button>
+          ))}
+        </div>
+      </aside>
+
+      {/* Lienzo central (vista construcción simple) */}
+      <main className="col-span-7 p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-xl font-semibold">{template.name} <span className="text-gray-400 text-sm">({template.status})</span></h2>
+          <div className="flex gap-2">
+            <button onClick={()=>setPreview(v=>!v)} className="px-3 py-1 rounded-lg bg-gray-800">{preview ? "Editar" : "Vista previa"}</button>
+            <button onClick={save} className="px-3 py-1 rounded-lg bg-blue-600">Guardar</button>
+            <button onClick={publish} className="px-3 py-1 rounded-lg bg-emerald-600">Publicar</button>
+          </div>
+        </div>
+
+        {!preview ? (
+          <div className="border border-dashed border-gray-700 rounded-xl p-4">
+            <p className="text-sm text-gray-400 mb-2">Fila 1 / Columna única</p>
+            <ul className="space-y-2">
+              {template.layout[0]?.children?.[0]?.children?.map((n,i)=>(
+                <li key={i} className="bg-gray-800 rounded-lg px-3 py-2 flex items-center justify-between">
+                  <span>{n.type==="field" ? n.fieldKey : n.type}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className="border border-gray-800 rounded-xl p-4 bg-gray-900">
+            <DynamicForm template={template} onSubmit={(v)=>console.log("preview submit", v)} />
+          </div>
+        )}
+      </main>
+
+      {/* Inspector derecho (propiedades básicas del último campo agregado) */}
+      <aside className="col-span-3 border-l border-gray-800 p-4">
+        <h3 className="font-semibold mb-3">Inspector</h3>
+        <p className="text-sm text-gray-400 mb-2">Seleccioná un campo en el lienzo (por ahora, editar el último agregado).</p>
+        {/* MVP: editar el último field */}
+        {(() => {
+          const kids = template.layout[0]?.children?.[0]?.children ?? [];
+          const last = kids.map(k=>k.fieldKey).filter(Boolean).pop();
+          const f = template.fields.find(x=>x.key===last);
+          if (!f) return <p className="text-sm text-gray-500">No hay campo seleccionado.</p>;
+          return (
+            <div className="space-y-2">
+              <div>
+                <label className="block text-sm mb-1 text-gray-300">Label</label>
+                <input value={f.label} onChange={e=>updateField(f.key, { label:e.target.value })}
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2" />
+              </div>
+              <div>
+                <label className="block text-sm mb-1 text-gray-300">Key</label>
+                <input value={f.key} onChange={e=>updateField(f.key, { key:e.target.value })}
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2" />
+              </div>
+              <div>
+                <label className="block text-sm mb-1 text-gray-300">Required</label>
+                <input type="checkbox" checked={!!f.required} onChange={e=>updateField(f.key, { required:e.target.checked })}
+                  className="w-4 h-4" />
+              </div>
+            </div>
+          );
+        })()}
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/app/plantillas/page.tsx
+++ b/frontend/src/app/plantillas/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { repo } from "@/lib/legajos/repo";
+import { Template } from "@/lib/legajos/schema";
+import { nanoid } from "nanoid";
+import { legajoCiudadano } from "@/lib/legajos/seeds";
+import { useClientGuard } from "@/lib/useClientGuard";
+
+export default function PlantillasList() {
+  useClientGuard();
+  const [items,setItems] = useState<Template[]>([]);
+  useEffect(()=>{ (async()=>{
+    const list = await repo.listTemplates();
+    if (list.length===0) {
+      await repo.upsertTemplate(legajoCiudadano);
+      setItems([legajoCiudadano]);
+    } else setItems(list);
+  })(); },[]);
+  const create = async () => {
+    const t: Template = {
+      id: nanoid(), name:"Legajo nuevo", slug:"legajo-nuevo",
+      version:"0.1.0", status:"draft", fields:[],
+      layout:[{type:"row", children:[{type:"col", span:12, children:[]}]}]
+    };
+    await repo.upsertTemplate(t);
+    location.href = `/plantillas/${t.id}/builder`;
+  };
+  return (
+    <main className="p-6 text-white">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Plantillas</h1>
+        <button onClick={create} className="px-3 py-1 rounded-lg bg-blue-600">Nueva plantilla</button>
+      </div>
+      <ul className="space-y-2">
+        {items.map(t=>(
+          <li key={t.id} className="border border-gray-800 rounded-xl p-3 flex items-center justify-between">
+            <div>
+              <div className="font-medium">{t.name}</div>
+              <div className="text-xs text-gray-400">{t.slug} · {t.status} · v{t.version}</div>
+            </div>
+            <div className="flex gap-2">
+              <Link href={`/plantillas/${t.id}/builder`} className="px-3 py-1 rounded-lg bg-gray-800">Editar</Link>
+              <Link href={`/legajos/nuevo?plantilla=${t.id}`} className="px-3 py-1 rounded-lg bg-emerald-700">Usar</Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/lib/legajos/builder/store.ts
+++ b/frontend/src/lib/legajos/builder/store.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { nanoid } from "nanoid";
+import { Template, FieldDef, LayoutNode } from "../schema";
+
+type BuilderState = {
+  template: Template;
+  selected?: { type: "field"|"node", key: string };
+  setTemplate: (t: Template) => void;
+  addField: (type: FieldDef["type"]) => FieldDef;
+  addFieldToLayout: (fieldKey: string, parentPath: number[]) => void; // parentPath = índices para llegar al contenedor
+  updateField: (key: string, patch: Partial<FieldDef>) => void;
+};
+
+export const useBuilder = create<BuilderState>((set,get)=>({
+  template: { id: nanoid(), name:"Nueva Plantilla", slug:"nueva-plantilla", version:"0.1.0", status:"draft", fields:[], layout:[{type:"row", children:[{type:"col", span:12, children:[]}]}]},
+  setTemplate: (t)=>set({ template: t }),
+  addField: (type) => {
+    const t = structuredClone(get().template);
+    const f: FieldDef = { id: nanoid(), key: `campo_${t.fields.length+1}`, type, label: "Nuevo campo" };
+    t.fields.push(f); set({ template: t }); return f;
+  },
+  addFieldToLayout: (fieldKey, parentPath) => {
+    const t = structuredClone(get().template);
+    // bajar por el árbol siguiendo parentPath
+    let node: LayoutNode = { type:"row", children:t.layout } as any;
+    let children = t.layout;
+    for (const idx of parentPath) {
+      const n = children[idx];
+      if (!n.children) n.children = [];
+      children = n.children;
+    }
+    children.push({ type:"field", fieldKey });
+    set({ template: t });
+  },
+  updateField: (key, patch) => {
+    const t = structuredClone(get().template);
+    const idx = t.fields.findIndex(f=>f.key===key);
+    if (idx>=0) t.fields[idx] = { ...t.fields[idx], ...patch };
+    set({ template: t });
+  }
+}));

--- a/frontend/src/lib/legajos/conditions.ts
+++ b/frontend/src/lib/legajos/conditions.ts
@@ -1,0 +1,17 @@
+import { Condition } from "./schema";
+
+export function evalConditions(conds: Condition[]|undefined, values: Record<string, any>): boolean {
+  if (!conds || conds.length===0) return true;
+  return conds.every(c => {
+    const v = values?.[c.key];
+    switch (c.op) {
+      case "exists": return v !== undefined && v !== null && v !== "";
+      case "equals": return v === c.value;
+      case "notEquals": return v !== c.value;
+      case "gt": return Number(v) > Number(c.value);
+      case "lt": return Number(v) < Number(c.value);
+      case "in": return Array.isArray(c.value) && c.value.includes(v);
+      default: return true;
+    }
+  });
+}

--- a/frontend/src/lib/legajos/renderer/Controls.tsx
+++ b/frontend/src/lib/legajos/renderer/Controls.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { Controller, UseFormReturn } from "react-hook-form";
+
+export function TextField({ form, name, label, placeholder, readOnly }:
+  { form: UseFormReturn<any>, name: string, label: string, placeholder?: string, readOnly?: boolean }) {
+  const { register } = form;
+  return (
+    <div className="mb-3">
+      <label className="block mb-1 text-sm text-gray-300">{label}</label>
+      <input {...register(name)} placeholder={placeholder}
+        readOnly={readOnly}
+        className="w-full rounded-lg border border-gray-600 bg-gray-700 text-white px-3 py-2 focus:ring-blue-500 focus:border-blue-500" />
+    </div>
+  );
+}
+
+export function NumberField({ form, name, label }:{ form:UseFormReturn<any>, name:string, label:string }) {
+  const { register } = form;
+  return (
+    <div className="mb-3">
+      <label className="block mb-1 text-sm text-gray-300">{label}</label>
+      <input type="number" {...register(name)} className="w-full rounded-lg border border-gray-600 bg-gray-700 text-white px-3 py-2" />
+    </div>
+  );
+}
+
+export function TextArea({ form, name, label }:{ form:UseFormReturn<any>, name:string, label:string }) {
+  const { register } = form;
+  return (
+    <div className="mb-3">
+      <label className="block mb-1 text-sm text-gray-300">{label}</label>
+      <textarea {...register(name)} className="w-full rounded-lg border border-gray-600 bg-gray-700 text-white px-3 py-2 min-h-[90px]" />
+    </div>
+  );
+}
+
+export function Checkbox({ form, name, label }:{ form:UseFormReturn<any>, name:string, label:string }) {
+  const { register } = form;
+  return (
+    <label className="flex items-center gap-2 mb-3 text-gray-300">
+      <input type="checkbox" {...register(name)} className="w-4 h-4 rounded border-gray-600 bg-gray-700" />
+      {label}
+    </label>
+  );
+}
+
+export function SelectField({ form, name, label, options }:{
+  form: UseFormReturn<any>, name:string, label:string, options: {value:string,label:string}[]
+}) {
+  const { control } = form;
+  return (
+    <div className="mb-3">
+      <label className="block mb-1 text-sm text-gray-300">{label}</label>
+      <Controller control={control} name={name} render={({ field }) => (
+        <select {...field} className="w-full rounded-lg border border-gray-600 bg-gray-700 text-white px-3 py-2">
+          <option value="">Seleccionar…</option>
+          {options?.map(o=> <option key={o.value} value={o.value}>{o.label}</option>)}
+        </select>
+      )}/>
+    </div>
+  );
+}

--- a/frontend/src/lib/legajos/renderer/Renderer.tsx
+++ b/frontend/src/lib/legajos/renderer/Renderer.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { useMemo } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { Template, LayoutNode, FieldDef } from "../schema";
+import { evalConditions } from "../conditions";
+import { TextField, NumberField, TextArea, Checkbox, SelectField } from "./Controls";
+
+function FieldControl({ field, values, form }:{ field: FieldDef, values: any, form: any }) {
+  // visibilidad condicional
+  const visible = evalConditions(field.showWhen, values);
+  if (!visible) return null;
+
+  switch (field.type) {
+    case "text": return <TextField form={form} name={field.key} label={field.label} placeholder={field.placeholder} readOnly={field.ui?.readOnly} />;
+    case "number": return <NumberField form={form} name={field.key} label={field.label} />;
+    case "textarea": return <TextArea form={form} name={field.key} label={field.label} />;
+    case "boolean": return <Checkbox form={form} name={field.key} label={field.label} />;
+    case "select": return <SelectField form={form} name={field.key} label={field.label} options={field.options ?? []} />;
+    default: return <div className="text-xs text-gray-400">Tipo no implementado: {field.type}</div>;
+  }
+}
+
+function findField(fields: FieldDef[], key?: string) {
+  return fields.find(f => f.key === key);
+}
+
+function Node({ node, template, form }:{ node: LayoutNode, template: Template, form:any }) {
+  const values = form.getValues();
+
+  if (node.type === "row") {
+    return <div className="grid grid-cols-12 gap-4">{node.children?.map((ch,i)=><Node key={i} node={ch} template={template} form={form} />)}</div>;
+  }
+  if (node.type === "col") {
+    const span = node.span ?? 12;
+    return <div className={`col-span-${Math.min(Math.max(span,1),12)}`}>{node.children?.map((ch,i)=><Node key={i} node={ch} template={template} form={form} />)}</div>;
+  }
+  if (node.type === "section") {
+    return (
+      <div className="border border-gray-700 rounded-xl p-4 mb-4">
+        {node.label && <h3 className="text-lg text-white font-semibold mb-3">{node.label}</h3>}
+        {node.children?.map((ch,i)=><Node key={i} node={ch} template={template} form={form} />)}
+      </div>
+    );
+  }
+  if (node.type === "field") {
+    const f = findField(template.fields, node.fieldKey);
+    return f ? <FieldControl field={f} values={values} form={form} /> : null;
+  }
+  // tabs / repeater quedan para siguiente commit del MVP
+  return null;
+}
+
+export default function DynamicForm({ template, defaultValues, onSubmit }:{
+  template: Template, defaultValues?: any, onSubmit?: (values:any)=>void
+}) {
+  const form = useForm({ defaultValues: useMemo(()=>defaultValues ?? {}, [defaultValues]) });
+  return (
+    <FormProvider {...form}>
+      <form className="space-y-2" onSubmit={form.handleSubmit(v => onSubmit?.(v))}>
+        {template.layout.map((n,i)=><Node key={i} node={n} template={template} form={form} />)}
+        <div className="pt-2">
+          <button type="submit" className="rounded-xl px-4 py-2 bg-blue-600 text-white">Guardar</button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/frontend/src/lib/legajos/repo.ts
+++ b/frontend/src/lib/legajos/repo.ts
@@ -1,0 +1,63 @@
+import { nanoid } from "nanoid";
+import { Template, templateSchema, Dossier, dossierSchema } from "./schema";
+
+type Id = string;
+
+export interface ITemplatesRepo {
+  listTemplates(): Promise<Template[]>;
+  getTemplate(id: Id): Promise<Template | null>;
+  upsertTemplate(t: Template): Promise<Template>;
+  publishTemplate(id: Id): Promise<Template>;
+  cloneTemplate(id: Id): Promise<Template>;
+  listDossiers(): Promise<Dossier[]>;
+  createDossier(d: Omit<Dossier,"id">): Promise<Dossier>;
+  getDossier(id: Id): Promise<Dossier | null>;
+  saveDossier(d: Dossier): Promise<Dossier>;
+}
+
+const kT = "legajos.templates";
+const kD = "legajos.dossiers";
+
+function get<T>(k:string, def:T): T {
+  if (typeof window === "undefined") return def;
+  const raw = localStorage.getItem(k);
+  return raw ? JSON.parse(raw) as T : def;
+}
+function set<T>(k:string, v:T) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(k, JSON.stringify(v));
+}
+
+export class LocalRepo implements ITemplatesRepo {
+  async listTemplates() { return get<Template[]>(kT, []); }
+  async getTemplate(id: Id) { return (await this.listTemplates()).find(t=>t.id===id) ?? null; }
+  async upsertTemplate(t: Template) {
+    const list = await this.listTemplates();
+    const idx = list.findIndex(x=>x.id===t.id);
+    const parsed = templateSchema.parse(t);
+    if (idx >= 0) list[idx] = parsed; else list.push(parsed);
+    set(kT, list); return parsed;
+  }
+  async publishTemplate(id: Id) {
+    const t = await this.getTemplate(id); if (!t) throw new Error("not found");
+    t.status = "published"; return this.upsertTemplate(t);
+  }
+  async cloneTemplate(id: Id) {
+    const t = await this.getTemplate(id); if (!t) throw new Error("not found");
+    const copy = { ...t, id: nanoid(), slug: `${t.slug}-copy`, name: `${t.name} (Copia)`, status: "draft" as const };
+    return this.upsertTemplate(copy);
+  }
+  async listDossiers() { return get<Dossier[]>(kD, []); }
+  async createDossier(d) {
+    const parsed = dossierSchema.parse({ id: nanoid(), ...d });
+    const list = await this.listDossiers(); list.push(parsed); set(kD, list); return parsed;
+  }
+  async getDossier(id: Id) { return (await this.listDossiers()).find(x=>x.id===id) ?? null; }
+  async saveDossier(d: Dossier) {
+    const list = await this.listDossiers();
+    const idx = list.findIndex(x=>x.id===d.id); if (idx<0) throw new Error("not found");
+    list[idx] = dossierSchema.parse(d); set(kD, list); return list[idx];
+  }
+}
+
+export const repo: ITemplatesRepo = new LocalRepo(); // TODO: luego reemplazar por API real

--- a/frontend/src/lib/legajos/schema.ts
+++ b/frontend/src/lib/legajos/schema.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+export const conditionOp = z.enum(["equals","notEquals","gt","lt","exists","in"]);
+export type ConditionOp = z.infer<typeof conditionOp>;
+
+export const conditionSchema = z.object({
+  key: z.string(),
+  op: conditionOp,
+  value: z.any().optional()
+});
+export type Condition = z.infer<typeof conditionSchema>;
+
+export const fieldType = z.enum([
+  "text","number","date","select","multiselect","boolean","textarea","file"
+]);
+export type FieldType = z.infer<typeof fieldType>;
+
+export const optionSchema = z.object({ value: z.string(), label: z.string() });
+
+export const fieldDefSchema = z.object({
+  id: z.string(),
+  key: z.string(),                // clave única dentro del template
+  type: fieldType,
+  label: z.string(),
+  help: z.string().optional(),
+  placeholder: z.string().optional(),
+  required: z.boolean().optional(),
+  defaultValue: z.any().optional(),
+  options: z.array(optionSchema).optional(), // para select/multiselect
+  ui: z.object({
+    colSpan: z.number().min(1).max(12).optional(),
+    readOnly: z.boolean().optional(),
+    mask: z.string().optional(),
+    prefix: z.string().optional(),
+    suffix: z.string().optional()
+  }).optional(),
+  showWhen: z.array(conditionSchema).optional(),
+  requiredWhen: z.array(conditionSchema).optional()
+});
+export type FieldDef = z.infer<typeof fieldDefSchema>;
+
+export const layoutNodeSchema = z.lazy(() => z.object({
+  type: z.enum(["row","col","section","tabs","tab","repeater","field"]),
+  label: z.string().optional(),
+  span: z.number().min(1).max(12).optional(),      // para col
+  fieldKey: z.string().optional(),                  // para field
+  children: z.array(layoutNodeSchema).optional(),
+  repeater: z.object({
+    columns: z.array(fieldDefSchema)
+  }).optional()
+}));
+export type LayoutNode = z.infer<typeof layoutNodeSchema>;
+
+export const templateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  category: z.string().optional(), // ciudadano/comedor/centro/...
+  version: z.string().default("0.1.0"),
+  status: z.enum(["draft","published","archived"]).default("draft"),
+  fields: z.array(fieldDefSchema),
+  layout: z.array(layoutNodeSchema),
+  rules: z.array(z.object({
+    when: z.array(conditionSchema),
+    enforce: z.array(z.object({ key: z.string(), required: z.boolean().optional() })).optional(),
+    visibility: z.array(z.object({ target: z.string(), show: z.boolean() })).optional()
+  })).optional()
+});
+export type Template = z.infer<typeof templateSchema>;
+
+export const dossierSchema = z.object({
+  id: z.string(),
+  templateId: z.string(),
+  templateVersion: z.string(),
+  status: z.enum(["draft","active","closed"]).default("draft"),
+  data: z.record(z.any())
+});
+export type Dossier = z.infer<typeof dossierSchema>;

--- a/frontend/src/lib/legajos/seeds.ts
+++ b/frontend/src/lib/legajos/seeds.ts
@@ -1,0 +1,30 @@
+import { Template } from "./schema";
+import { nanoid } from "nanoid";
+
+export const legajoCiudadano: Template = {
+  id: "tmpl_ciudadano",
+  name: "Legajo Ciudadano",
+  slug: "legajo-ciudadano",
+  version: "1.0.0",
+  status: "published",
+  fields: [
+    { id: nanoid(), key: "nombre",   type:"text",    label:"Nombre", required:true },
+    { id: nanoid(), key: "apellido", type:"text",    label:"Apellido", required:true },
+    { id: nanoid(), key: "dni",      type:"text",    label:"DNI" },
+    { id: nanoid(), key: "fecha_nac",type:"date",    label:"Fecha de nacimiento" },
+    { id: nanoid(), key: "telefono", type:"text",    label:"Teléfono" },
+    { id: nanoid(), key: "genero",   type:"select",  label:"Género", options:[
+      {value:"f",label:"Femenino"},{value:"m",label:"Masculino"},{value:"x",label:"No binario"},{value:"o",label:"Otro"}
+    ]},
+    { id: nanoid(), key: "notas",    type:"textarea",label:"Notas" },
+    { id: nanoid(), key: "acepta",   type:"boolean", label:"Acepta términos" }
+  ],
+  layout: [
+    { type:"row", children:[
+      { type:"col", span:6, children:[ {type:"field", fieldKey:"nombre"}, {type:"field", fieldKey:"apellido"}, {type:"field", fieldKey:"dni"} ]},
+      { type:"col", span:6, children:[ {type:"field", fieldKey:"fecha_nac"}, {type:"field", fieldKey:"telefono"}, {type:"field", fieldKey:"genero"} ]}
+    ]},
+    { type:"section", label:"Notas", children:[ {type:"field", fieldKey:"notas"}, {type:"field", fieldKey:"acepta"} ] }
+  ],
+  rules: []
+};

--- a/frontend/src/lib/useClientGuard.ts
+++ b/frontend/src/lib/useClientGuard.ts
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export function useClientGuard() {
+  const r = useRouter();
+  useEffect(()=>{
+    const token = typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
+    if (!token) r.replace("/login");
+  },[r]);
+}


### PR DESCRIPTION
## Summary
- add comprehensive template and dossier schemas
- create localStorage-backed repository with condition evaluator and dynamic renderer
- implement template builder with seeds, pages, and auth guard

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c416161e3c832daad4ba5f16f3612c