### PR TITLE
feat: enable JWT login for Django users

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,10 +1,25 @@
 from django.contrib.auth.models import User
-from rest_framework.generics import ListAPIView
-from rest_framework.permissions import IsAuthenticated  # cambia a IsAdminUser si querés solo admins
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework.filters import SearchFilter, OrderingFilter
+from rest_framework.filters import OrderingFilter, SearchFilter
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.views import TokenObtainPairView
 
-from .serializers import UserSerializer
+from .serializers import CustomTokenObtainPairSerializer, UserSerializer
+
+
+class CustomTokenObtainPairView(TokenObtainPairView):
+    serializer_class = CustomTokenObtainPairSerializer
+
+
+class AuthMeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response(UserSerializer(request.user).data)
+
 
 class UserListAPIView(ListAPIView):
     queryset = User.objects.all().order_by("id")

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,8 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { me, logout } from "@/lib/auth";
+
 export default function DashboardPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const u = await me();
+        setUser(u);
+      } catch {
+        router.replace("/login");
+      }
+    })();
+  }, [router]);
+
+  if (!user) return null;
+
   return (
-    <div className="flex items-center justify-center h-screen bg-gray-900 text-white">
-      <h1 className="text-3xl font-semibold">Bienvenido</h1>
-    </div>
+    <main className="p-6">
+      <div className="max-w-3xl mx-auto">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Hola, {user.username || user.email}</h1>
+          <button
+            onClick={() => {
+              logout();
+              router.replace("/login");
+            }}
+            className="rounded-lg border px-3 py-1.5"
+          >
+            Cerrar sesión
+          </button>
+        </div>
+        <p className="text-gray-600 mt-2">Home básico. Acá va el contenido.</p>
+      </div>
+    </main>
   );
 }
-

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,197 +5,87 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { login } from "@/lib/auth";
 
-// Esquema de validación con Zod
-const loginSchema = z.object({
-  email: z
-    .string()
-    .email({ message: "Enter a valid email address" }),
-  password: z
-    .string()
-    .min(1, { message: "Please enter your password" }),
+const schema = z.object({
+  identifier: z.string().min(3, "Ingresá usuario o email"),
+  password: z.string().min(1, "Ingresá tu contraseña"),
+  remember: z.boolean().default(true),
 });
-type LoginFormData = z.infer<typeof loginSchema>;
+type FormData = z.infer<typeof schema>;
 
 export default function LoginPage() {
   const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
   const {
     register,
     handleSubmit,
-    formState: { errors },
-  } = useForm<LoginFormData>({
-    resolver: zodResolver(loginSchema),
-  });
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema), defaultValues: { remember: true } });
 
-  // Maneja el submit del formulario
-  const onSubmit = async (data: LoginFormData) => {
-    setErrorMsg(null);
+  const onSubmit = async (data: FormData) => {
+    setError(null);
     try {
-      const res = await fetch("http://localhost:8000/api/token/", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: data.email, password: data.password }),
-      });
-      if (!res.ok) {
-        throw new Error("Invalid credentials");
-      }
-      const tokenData = await res.json();
-      // Guardar token JWT en localStorage
-      localStorage.setItem("token", tokenData.access);
-      // Redirigir al dashboard
-      router.push("/dashboard");
-    } catch (error) {
-      // Mostrar mensaje de error en caso de fallo
-      setErrorMsg("Invalid email or password.");
+      await login(data.identifier, data.password, data.remember);
+      router.replace("/dashboard");
+    } catch (e: any) {
+      setError(e.message || "Error de autenticación");
     }
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-900">
-      {/* Contenedor del card de login */}
-      <div className="max-w-4xl w-full bg-gray-800 text-white rounded-lg shadow md:flex overflow-hidden">
-        {/* Sección izquierda: formulario */}
-        <div className="w-full md:w-1/2 p-6 space-y-6">
-          <h2 className="text-2xl font-bold text-white">
-            Sign in to your account
-          </h2>
-          {/* Botones sociales (decorativos) */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <button
-              type="button"
-              className="w-full text-white bg-[#4285F4] hover:bg-[#4285F4]/90 focus:ring-4 focus:ring-[#4285F4]/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:focus:ring-[#4285F4]/55"
-            >
-              {/* Icono de Google */}
-              <svg
-                className="mr-2 -ml-1 w-4 h-4"
-                aria-hidden="true"
-                focusable="false"
-                data-icon="google"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 488 512"
-              >
-                <path
-                  fill="currentColor"
-                  d="M488 261.8C488 403.3 391.1 504 248 504...41.4z"
-                ></path>
-              </svg>
-              Sign in with Google
-            </button>
-            <button
-              type="button"
-              className="w-full text-white bg-[#050708] hover:bg-[#050708]/90 focus:ring-4 focus:ring-[#050708]/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:focus:ring-[#050708]/50 dark:hover:bg-[#050708]/30"
-            >
-              {/* Icono de Apple */}
-              <svg
-                className="mr-2 -ml-1 w-5 h-5"
-                aria-hidden="true"
-                focusable="false"
-                data-icon="apple"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 384 512"
-              >
-                <path
-                  fill="currentColor"
-                  d="M318.7 268.7c-0.2-36.7 16.4-64.4 50-84.8...69.5-34.3z"
-                ></path>
-              </svg>
-              Sign in with Apple
-            </button>
-          </div>
-          {/* Separador "Or" */}
-          <div className="flex items-center my-4">
-            <hr className="w-full border-gray-600" />
-            <span className="px-3 text-gray-400 text-sm">Or</span>
-            <hr className="w-full border-gray-600" />
-          </div>
-          {/* Mensaje de error si las credenciales son inválidas */}
-          {errorMsg && (
-            <p className="text-sm text-red-500">{errorMsg}</p>
-          )}
-          {/* Formulario de email y contraseña */}
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            <div>
-              <label
-                htmlFor="email"
-                className="block mb-1 text-sm font-medium text-gray-300"
-              >
-                Email
-              </label>
-              <input
-                type="email"
-                id="email"
-                {...register("email")}
-                className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
-                placeholder="name@company.com"
-                required
-              />
-              {errors.email && (
-                <p className="text-xs text-red-500 mt-1">
-                  {errors.email.message}
-                </p>
-              )}
-            </div>
-            <div>
-              <label
-                htmlFor="password"
-                className="block mb-1 text-sm font-medium text-gray-300"
-              >
-                Password
-              </label>
-              <input
-                type="password"
-                id="password"
-                {...register("password")}
-                className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
-                placeholder="••••••••"
-                required
-              />
-              {errors.password && (
-                <p className="text-xs text-red-500 mt-1">
-                  {errors.password.message}
-                </p>
-              )}
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center">
-                <input
-                  id="remember"
-                  type="checkbox"
-                  className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded"
-                />
-                <label
-                  htmlFor="remember"
-                  className="ml-2 text-sm font-medium text-gray-300"
-                >
-                  Remember me
-                </label>
-              </div>
-              <a href="#" className="text-sm text-blue-500 hover:underline">
-                Forgot password?
-              </a>
-            </div>
-            <button
-              type="submit"
-              className="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-            >
-              Sign in to your account
-            </button>
-          </form>
-          <p className="text-sm text-gray-400 mt-4">
-            Don’t have an account?{' '}
-            <a href="#" className="font-medium text-blue-500 hover:underline">
-              Sign up
-            </a>
-          </p>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow p-6 space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold">Iniciar sesión</h1>
+          <p className="text-sm text-gray-500">Usá tu usuario o email y contraseña</p>
         </div>
-        {/* Sección derecha: ilustración */}
-        <div
-          className="hidden md:flex md:w-1/2 bg-cover bg-center"
-          style={{ backgroundImage: "url('/path/to/illustration.png')" }}
-        />
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="text-sm font-medium">Usuario o email</label>
+            <input
+              className="mt-1 w-full rounded-xl border px-3 py-2 outline-none focus:ring-2 focus:ring-black/10"
+              placeholder="usuario o correo"
+              {...register("identifier")}
+            />
+            {errors.identifier && <p className="text-xs text-red-600 mt-1">{errors.identifier.message}</p>}
+          </div>
+          <div>
+            <label className="text-sm font-medium">Contraseña</label>
+            <input
+              type="password"
+              className="mt-1 w-full rounded-xl border px-3 py-2 outline-none focus:ring-2 focus:ring-black/10"
+              placeholder="••••••••"
+              {...register("password")}
+            />
+            {errors.password && <p className="text-xs text-red-600 mt-1">{errors.password.message}</p>}
+          </div>
+
+          <div className="flex items-center justify-between">
+            <label className="inline-flex items-center gap-2 text-sm">
+              <input type="checkbox" className="rounded" {...register("remember")} />
+              Recordarme
+            </label>
+            <a className="text-sm text-gray-500 hover:underline" href="#">¿Olvidaste tu contraseña?</a>
+          </div>
+
+          {error && <div className="text-sm text-red-600">{error}</div>}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-xl bg-black text-white py-2.5 disabled:opacity-50"
+          >
+            {isSubmitting ? "Ingresando..." : "Ingresar"}
+          </button>
+
+          <div className="flex items-center gap-2">
+            <button disabled className="flex-1 rounded-xl border py-2.5">Continuar con Google</button>
+            <button disabled className="flex-1 rounded-xl border py-2.5">Continuar con Apple</button>
+          </div>
+        </form>
       </div>
     </div>
   );
 }
-

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,86 @@
+"use client";
+
+const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+type Tokens = { access: string; refresh: string };
+
+const LS_ACCESS = "access_token";
+const LS_REFRESH = "refresh_token";
+
+export function getTokens(): Tokens | null {
+  const access = typeof window !== "undefined" ? localStorage.getItem(LS_ACCESS) : null;
+  const refresh = typeof window !== "undefined" ? localStorage.getItem(LS_REFRESH) : null;
+  return access && refresh ? { access, refresh } : null;
+}
+
+export function setTokens(t: Tokens) {
+  localStorage.setItem(LS_ACCESS, t.access);
+  localStorage.setItem(LS_REFRESH, t.refresh);
+}
+
+export function clearTokens() {
+  localStorage.removeItem(LS_ACCESS);
+  localStorage.removeItem(LS_REFRESH);
+}
+
+async function refreshAccessToken(): Promise<string | null> {
+  const tokens = getTokens();
+  if (!tokens) return null;
+  const res = await fetch(`${API}/api/token/refresh/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refresh: tokens.refresh }),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  const access = data.access as string;
+  setTokens({ access, refresh: tokens.refresh });
+  return access;
+}
+
+export async function authFetch(input: RequestInfo, init: RequestInit = {}): Promise<Response> {
+  let access = getTokens()?.access;
+  const headers = new Headers(init.headers);
+  if (access) headers.set("Authorization", `Bearer ${access}`);
+  headers.set("Content-Type", headers.get("Content-Type") || "application/json");
+
+  let res = await fetch(input, { ...init, headers });
+  if (res.status !== 401) return res;
+
+  // reintento con refresh
+  const newAccess = await refreshAccessToken();
+  if (!newAccess) return res;
+  headers.set("Authorization", `Bearer ${newAccess}`);
+  res = await fetch(input, { ...init, headers });
+  return res;
+}
+
+export async function login(identifier: string, password: string, remember = true) {
+  const body = { identifier, password, username: identifier }; // backend aceptará email/username
+  const res = await fetch(`${API}/api/token/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Credenciales inválidas");
+  }
+  const data = (await res.json()) as Tokens;
+  setTokens(data);
+  if (!remember) {
+    // opción simple: limpiar refresh al cerrar tab
+    window.addEventListener("beforeunload", () => clearTokens());
+  }
+}
+
+export async function me() {
+  const res = await authFetch(`${API}/api/auth/me/`, { method: "GET" });
+  if (!res.ok) throw new Error("No autenticado");
+  return res.json();
+}
+
+export function logout() {
+  clearTokens();
+  // Opcional: invalidate react-query aquí si lo usás
+}


### PR DESCRIPTION
## Summary
- allow JWT token issuance via username or email
- add auth helpers for storing tokens and refreshing
- implement login and protected dashboard pages

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4251c3400832d9a139dbf1099536c