### PR TITLE
Add client guard to home page and test redirect

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "echo \"No tests specified\""
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
@@ -33,6 +33,10 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^15.0.1",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,19 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import HomePage from "./page";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+}));
+
+describe("HomePage", () => {
+  it("redirects to /login when no access_token exists", async () => {
+    render(<HomePage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/login");
+    });
+  });
+});
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,10 @@
+"use client";
+
+import { useClientGuard } from "@/lib/useClientGuard";
+
 export default function HomePage() {
+  useClientGuard();
+
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold">Home</h1>

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});
+

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,2 @@
+import "@testing-library/jest-dom";
+


### PR DESCRIPTION
## Summary
- make home page a client component that redirects to login when no token
- add test coverage and Vitest config for redirect behavior

## Testing
- `npm test` *(fails: vitest not found due to failed dependency install)*


------
https://chatgpt.com/codex/tasks/task_e_68c42a96f560832db92325563747b647