### PR TITLE
Normalize email identifier to username for login

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -33,8 +33,8 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             or self.initial_data.get("identifier")
             or self.initial_data.get("email")
         )
-        password = attrs.get("password")
-        if identifier and "@" in identifier and not attrs.get("username"):
+
+        if identifier and "@" in identifier:
             try:
                 user = User.objects.get(email__iexact=identifier)
                 attrs["username"] = getattr(
@@ -43,4 +43,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             except User.DoesNotExist:
                 # Dejar que SimpleJWT falle con credenciales inválidas
                 pass
+        else:
+            attrs["username"] = identifier
+
         return super().validate(attrs)


### PR DESCRIPTION
## Summary
- Normalize email identifiers to usernames in `CustomTokenObtainPairSerializer`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4316cdd64832dbc88ebbd8d78fa7a