### PR TITLE
feat(frontend): add mobile overlay for sidebar

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode, useState } from 'react';
+import clsx from 'clsx';
+
+interface MainLayoutProps {
+  children: ReactNode;
+}
+
+export default function MainLayout({ children }: MainLayoutProps) {
+  const [sideOpen, setSideOpen] = useState(false);
+
+  return (
+    <div className="flex">
+      {/** Overlay visible only on mobile when sidebar is open */}
+      <div
+        className={clsx(
+          'fixed inset-0 bg-black/50 transition-opacity duration-300 md:hidden',
+          sideOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        )}
+        onClick={() => setSideOpen(false)}
+      />
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add mobile-only overlay that closes sidebar on click

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest/-/vitest-1.5.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68c435eb7f3c832d88d854245277d3d7