### PR TITLE
Add body overflow toggle in MainLayout

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,26 +1,40 @@
-"use client";
+'use client';
 
-import { useEffect, ReactNode } from "react";
+import { ReactNode, useEffect, useState } from 'react';
+import clsx from 'clsx';
 
 interface MainLayoutProps {
   children: ReactNode;
-  sideOpen: boolean;
-  controlOpen: boolean;
 }
 
-export default function MainLayout({ children, sideOpen, controlOpen }: MainLayoutProps) {
+export default function MainLayout({ children }: MainLayoutProps) {
+  const [sideOpen, setSideOpen] = useState(false);
+  const [controlOpen] = useState(false);
+
   useEffect(() => {
     const body = document.body;
     if (sideOpen || controlOpen) {
-      body.classList.add("overflow-hidden");
+      body.classList.add('overflow-hidden');
     } else {
-      body.classList.remove("overflow-hidden");
+      body.classList.remove('overflow-hidden');
     }
 
     return () => {
-      body.classList.remove("overflow-hidden");
+      body.classList.remove('overflow-hidden');
     };
   }, [sideOpen, controlOpen]);
 
-  return <>{children}</>;
+  return (
+    <div className="flex">
+      {/** Overlay visible only on mobile when sidebar is open */}
+      <div
+        className={clsx(
+          'fixed inset-0 bg-black/50 transition-opacity duration-300 md:hidden',
+          sideOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        )}
+        onClick={() => setSideOpen(false)}
+      />
+      <div className="flex-1">{children}</div>
+    </div>
+  );
 }

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, ReactNode } from "react";
+
+interface MainLayoutProps {
+  children: ReactNode;
+  sideOpen: boolean;
+  controlOpen: boolean;
+}
+
+export default function MainLayout({ children, sideOpen, controlOpen }: MainLayoutProps) {
+  useEffect(() => {
+    const body = document.body;
+    if (sideOpen || controlOpen) {
+      body.classList.add("overflow-hidden");
+    } else {
+      body.classList.remove("overflow-hidden");
+    }
+
+    return () => {
+      body.classList.remove("overflow-hidden");
+    };
+  }, [sideOpen, controlOpen]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- Add MainLayout component that toggles `overflow-hidden` on `<body>` based on layout state

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c43735a8e4832d8e5e1d72da2f5a68