### PR TITLE
Redirect root path to login page

### DIFF
--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,19 +1,13 @@
-import { render, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
+import { redirect } from "next/navigation";
 import HomePage from "./page";
 
-const replace = vi.fn();
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace }),
-}));
-
 describe("HomePage", () => {
-  it("redirects to /login when no access_token exists", async () => {
-    render(<HomePage />);
-
-    await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith("/login");
-    });
+  it("redirects to /login", () => {
+    HomePage();
+    expect(redirect).toHaveBeenCalledWith("/login");
   });
 });
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,13 +1,5 @@
-"use client";
-
-import { useClientGuard } from "@/lib/useClientGuard";
+import { redirect } from "next/navigation";
 
 export default function HomePage() {
-  useClientGuard();
-
-  return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold">Home</h1>
-    </main>
-  );
+  redirect("/login");
 }


### PR DESCRIPTION
## Summary
- Redirect `/` to `/login` using Next.js navigation
- Update home page test to check for redirect behavior

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c43b135590832d8015bd7595c97cbd