### PR TITLE
feat: show navigation menus on dashboard

### DIFF
--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import MainLayout from '@/components/layout/MainLayout';
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return <MainLayout>{children}</MainLayout>;
+}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,9 +1,9 @@
-
 'use client';
 
 import { ReactNode, useEffect, useState } from 'react';
-
 import clsx from 'clsx';
+import Sidebar from './Sidebar';
+import Topbar from './Topbar';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -12,24 +12,20 @@ interface MainLayoutProps {
 export default function MainLayout({ children }: MainLayoutProps) {
   const [sideOpen, setSideOpen] = useState(false);
 
-  const [controlOpen] = useState(false);
-
   useEffect(() => {
     const body = document.body;
-    if (sideOpen || controlOpen) {
+    if (sideOpen) {
       body.classList.add('overflow-hidden');
     } else {
       body.classList.remove('overflow-hidden');
     }
-
     return () => {
       body.classList.remove('overflow-hidden');
     };
-  }, [sideOpen, controlOpen]);
-
+  }, [sideOpen]);
 
   return (
-    <div className="flex">
+    <div className="flex min-h-screen">
       {/** Overlay visible only on mobile when sidebar is open */}
       <div
         className={clsx(
@@ -38,7 +34,11 @@ export default function MainLayout({ children }: MainLayoutProps) {
         )}
         onClick={() => setSideOpen(false)}
       />
-      <div className="flex-1">{children}</div>
+      <Sidebar open={sideOpen} onClose={() => setSideOpen(false)} />
+      <div className="flex-1 flex flex-col md:ml-64">
+        <Topbar onToggleSidebar={() => setSideOpen((o) => !o)} />
+        <main className="flex-1">{children}</main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+import clsx from 'clsx';
+
+const links = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/legajos', label: 'Legajos' },
+  { href: '/plantillas', label: 'Plantillas' }
+];
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
+  return (
+    <aside
+      className={clsx(
+        'fixed inset-y-0 left-0 w-64 bg-white shadow-md transform transition-transform duration-300 md:static md:translate-x-0 z-40',
+        open ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
+      )}
+    >
+      <nav className="p-4 space-y-2">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="block rounded-lg px-3 py-2 hover:bg-gray-100"
+            onClick={onClose}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+interface TopbarProps {
+  onToggleSidebar: () => void;
+}
+
+export default function Topbar({ onToggleSidebar }: TopbarProps) {
+  return (
+    <header className="h-14 bg-white border-b flex items-center px-4 shadow-sm">
+      <button
+        className="md:hidden mr-2 text-xl"
+        onClick={onToggleSidebar}
+        aria-label="Toggle sidebar"
+      >
+        &#9776;
+      </button>
+      <span className="font-semibold">Nodo</span>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add sidebar and topbar components and integrate with main layout
- wrap dashboard page with layout so menus are displayed
- remove node_modules ignore rule from gitignore

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd frontend && npm test` *(fails: vitest: not found)*
- `cd backend && pytest` *(passes: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68c43c1ae35c832d8120e95f49beaec3