### PR TITLE
Hide navigation on login page

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode, useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import TopNavBar from './TopNavBar';
 import SideNav from './SideNav';
@@ -12,6 +13,10 @@ interface MainLayoutProps {
 }
 
 export default function MainLayout({ children }: MainLayoutProps) {
+  const pathname = usePathname();
+  if (pathname.startsWith('/login')) {
+    return <>{children}</>;
+  }
   const [isSideOpen, setIsSideOpen] = useState(false);
   const [isMini, setIsMini] = useState(false);
   const [isControlOpen, setIsControlOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Hide sidebar and top nav on `/login` by bypassing MainLayout when the route is `/login`

## Testing
- `npm test` *(fails: vitest not found; installing dev deps fails with 403 Forbidden for @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c441dad748832d8d6f8add42d02ca2