### PR TITLE
Fix top bar alignment with sidebar

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -62,12 +62,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
 
       <SideNav open={isSideOpen} mini={isMini} onToggleMini={() => setIsMini((m) => !m)} />
 
-      <div
-        className={clsx(
-          'flex min-h-screen flex-1 flex-col transition-all duration-200',
-          isMini ? 'md:ml-16' : 'md:ml-64'
-        )}
-      >
+      <div className="flex min-h-screen flex-1 flex-col transition-all duration-200">
         <TopNavBar
           onToggleSideNav={() => setIsSideOpen((o) => !o)}
           onToggleControl={() => setIsControlOpen(true)}


### PR DESCRIPTION
## Summary
- remove hard-coded left margin from main layout so top bar and content align with the sidebar

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c44f7906d0832d805779e87230a2dd