### PR TITLE
feat: add template builder scaffolding

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     'django_filters',
     'corsheaders',
     'users',
+    'templates_app',
 ]
 
 MIDDLEWARE = [

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
 
     # Apps
     path("api/users/", include("users.urls")),
+    path("api/", include("templates_app.urls")),
 ]

--- a/backend/templates_app/migrations/0001_initial.py
+++ b/backend/templates_app/migrations/0001_initial.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+import uuid
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Template',
+            fields=[
+                ('id', models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, serialize=False)),
+                ('name', models.CharField(max_length=255)),
+                ('version', models.PositiveIntegerField(default=1)),
+                ('schema', models.JSONField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('created_by', models.ForeignKey(null=True, blank=True, on_delete=models.SET_NULL, related_name='templates', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Record',
+            fields=[
+                ('id', models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, serialize=False)),
+                ('data', models.JSONField()),
+                ('files', models.JSONField(blank=True, null=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('template', models.ForeignKey(on_delete=models.CASCADE, related_name='records', to='templates_app.template')),
+            ],
+        ),
+    ]

--- a/backend/templates_app/models.py
+++ b/backend/templates_app/models.py
@@ -1,0 +1,35 @@
+import uuid
+from django.db import models
+from django.conf import settings
+
+class Template(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    version = models.PositiveIntegerField(default=1)
+    schema = models.JSONField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="templates",
+    )
+
+    class Meta:
+        ordering = ["-updated_at"]
+
+    def __str__(self):
+        return self.name
+
+class Record(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    template = models.ForeignKey(Template, on_delete=models.CASCADE, related_name="records")
+    data = models.JSONField()
+    files = models.JSONField(blank=True, null=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-created_at"]

--- a/backend/templates_app/serializers.py
+++ b/backend/templates_app/serializers.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+from .models import Template, Record
+
+class TemplateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Template
+        fields = "__all__"
+        read_only_fields = ("id", "created_at", "updated_at", "version", "created_by")
+
+    def create(self, validated_data):
+        user = self.context.get("request").user
+        validated_data["created_by"] = user if user and user.is_authenticated else None
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        validated_data["version"] = instance.version + 1
+        return super().update(instance, validated_data)
+
+class RecordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Record
+        fields = "__all__"
+        read_only_fields = ("id", "created_at", "updated_at")

--- a/backend/templates_app/tests/test_models.py
+++ b/backend/templates_app/tests/test_models.py
@@ -1,0 +1,10 @@
+import pytest
+from django.contrib.auth import get_user_model
+from templates_app.models import Template
+
+@pytest.mark.django_db
+def test_create_template():
+    user_model = get_user_model()
+    user = user_model.objects.create(username="u")
+    tpl = Template.objects.create(name="t1", schema={}, created_by=user)
+    assert tpl.version == 1

--- a/backend/templates_app/urls.py
+++ b/backend/templates_app/urls.py
@@ -1,0 +1,8 @@
+from rest_framework import routers
+from .views import TemplateViewSet, RecordViewSet
+
+router = routers.DefaultRouter()
+router.register(r'templates', TemplateViewSet)
+router.register(r'records', RecordViewSet)
+
+urlpatterns = router.urls

--- a/backend/templates_app/views.py
+++ b/backend/templates_app/views.py
@@ -1,0 +1,15 @@
+from rest_framework import viewsets, permissions
+from rest_framework.parsers import MultiPartParser, JSONParser
+from .models import Template, Record
+from .serializers import TemplateSerializer, RecordSerializer
+
+class TemplateViewSet(viewsets.ModelViewSet):
+    serializer_class = TemplateSerializer
+    queryset = Template.objects.all()
+    permission_classes = [permissions.IsAuthenticated]
+
+class RecordViewSet(viewsets.ModelViewSet):
+    serializer_class = RecordSerializer
+    queryset = Record.objects.all()
+    permission_classes = [permissions.IsAuthenticated]
+    parser_classes = [MultiPartParser, JSONParser]

--- a/frontend/src/app/(dashboard)/legajos/nuevo/page.tsx
+++ b/frontend/src/app/(dashboard)/legajos/nuevo/page.tsx
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import DynamicForm from '@/components/runtime/DynamicForm';
+
+export default function NewRecordPage() {
+  const { data } = useQuery({ queryKey: ['templates'], queryFn: () => api.get('/templates/').then(res => res.data) });
+  if (!data) return <div>Sin plantillas</div>;
+  const template = data[0];
+  return <DynamicForm template={template} onSubmit={(d)=>api.post('/records/', d)} />;
+}

--- a/frontend/src/app/(dashboard)/plantillas/[id]/editar/page.tsx
+++ b/frontend/src/app/(dashboard)/plantillas/[id]/editar/page.tsx
@@ -1,0 +1,12 @@
+import Builder from '@/components/builder/Builder';
+import { api } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+
+export default function EditTemplatePage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const { data } = useQuery({ queryKey: ['template', id], queryFn: () => api.get(`/templates/${id}/`).then(res => res.data), enabled: !!id });
+  if (!data) return <div>Cargando...</div>;
+  return <Builder template={data} />;
+}

--- a/frontend/src/app/(dashboard)/plantillas/nueva/page.tsx
+++ b/frontend/src/app/(dashboard)/plantillas/nueva/page.tsx
@@ -1,0 +1,5 @@
+import Builder from '@/components/builder/Builder';
+
+export default function NewTemplatePage() {
+  return <Builder />;
+}

--- a/frontend/src/app/(dashboard)/plantillas/page.tsx
+++ b/frontend/src/app/(dashboard)/plantillas/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export default function TemplatesPage() {
+  const { data } = useQuery({ queryKey: ['templates'], queryFn: () => api.get('/templates/').then(res => res.data) });
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Plantillas</h1>
+      <Link href="/plantillas/nueva" className="text-blue-600">Nueva plantilla</Link>
+      <ul className="mt-4 space-y-2">
+        {data?.map((t: any) => (
+          <li key={t.id} className="border p-2 rounded">
+            {t.name} v{t.version}
+            <Link href={`/plantillas/${t.id}/editar`} className="ml-2 text-sm text-blue-600">Editar</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/builder/Builder.tsx
+++ b/frontend/src/components/builder/Builder.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { useTemplateStore } from '@/store/useTemplateStore';
+import Canvas from './Canvas';
+import Palette from './Palette';
+import PropertyPanel from './PropertyPanel';
+
+export default function Builder({ template }: { template?: any }) {
+  const { nodes, setTemplate } = useTemplateStore();
+  if (template) setTemplate(template);
+  return (
+    <div className="flex">
+      <Canvas />
+      <Palette />
+      <PropertyPanel />
+    </div>
+  );
+}

--- a/frontend/src/components/builder/Canvas.tsx
+++ b/frontend/src/components/builder/Canvas.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { useTemplateStore } from '@/store/useTemplateStore';
+
+export default function Canvas() {
+  const { nodes } = useTemplateStore();
+  return (
+    <div className="flex-1 border-dashed border-2 p-4 min-h-[400px]">
+      {nodes.map(n => (
+        <div key={n.id} className="p-2 border mb-2">{n.label || n.type}</div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/builder/FieldCards.tsx
+++ b/frontend/src/components/builder/FieldCards.tsx
@@ -1,0 +1,2 @@
+'use client';
+export default function FieldCards(){return null;}

--- a/frontend/src/components/builder/Palette.tsx
+++ b/frontend/src/components/builder/Palette.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { useTemplateStore } from '@/store/useTemplateStore';
+import { nanoid } from 'nanoid';
+
+const types = ['text','number','select','section'];
+
+export default function Palette() {
+  const { addNode } = useTemplateStore();
+  return (
+    <div className="w-48 p-2">
+      <h2>Campos</h2>
+      {types.map(t => (
+        <button key={t} className="block w-full border p-1 mb-2" onClick={()=>addNode({id:nanoid(), type:t, label:t, key:t+nanoid(4)})}>{t}</button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/builder/PropertyPanel.tsx
+++ b/frontend/src/components/builder/PropertyPanel.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useTemplateStore } from '@/store/useTemplateStore';
+
+export default function PropertyPanel() {
+  const { selected, updateNode } = useTemplateStore();
+  if (!selected) return <div className="w-64 p-2">Selecciona un campo</div>;
+  return (
+    <div className="w-64 p-2">
+      <input className="border w-full" value={selected.label} onChange={e=>updateNode(selected.id,{label:e.target.value})} />
+    </div>
+  );
+}

--- a/frontend/src/components/runtime/DynamicForm.tsx
+++ b/frontend/src/components/runtime/DynamicForm.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { useForm } from 'react-hook-form';
+
+export default function DynamicForm({ template, onSubmit }: { template: any; onSubmit: (data: any) => void }) {
+  const { register, handleSubmit } = useForm();
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      {template.nodes?.map((n: any) => {
+        if (n.type === 'text') return <div key={n.id}><label>{n.label}<input {...register(n.key)} className="border"/></label></div>;
+        if (n.type === 'number') return <div key={n.id}><label>{n.label}<input type="number" {...register(n.key)} className="border"/></label></div>;
+        return null;
+      })}
+      <button type="submit" className="border px-4 py-1">Guardar</button>
+    </form>
+  );
+}

--- a/frontend/src/components/runtime/TextField.tsx
+++ b/frontend/src/components/runtime/TextField.tsx
@@ -1,0 +1,2 @@
+'use client';
+export default function TextField(){return null;}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,19 @@
-export async function fetcher<T>(url: string): Promise<T> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`);
+export async function fetcher<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
   if (!res.ok) {
     throw new Error('API error');
   }
   return res.json() as Promise<T>;
 }
+
+export const api = {
+  get: (url: string) => fetcher(url),
+  post: (url: string, data: any) => fetcher(url, { method: 'POST', body: JSON.stringify(data) }),
+  put: (url: string, data: any) => fetcher(url, { method: 'PUT', body: JSON.stringify(data) }),
+};

--- a/frontend/src/lib/query.ts
+++ b/frontend/src/lib/query.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();

--- a/frontend/src/lib/schema.ts
+++ b/frontend/src/lib/schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const FieldNodeSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  key: z.string().optional(),
+  label: z.string().optional(),
+});
+
+export const TemplateSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  version: z.number().optional(),
+  nodes: z.array(FieldNodeSchema),
+});
+
+export type Template = z.infer<typeof TemplateSchema>;

--- a/frontend/store/useTemplateStore.ts
+++ b/frontend/store/useTemplateStore.ts
@@ -1,0 +1,19 @@
+'use client';
+import { create } from 'zustand';
+import { nanoid } from 'nanoid';
+import { Template } from '@/lib/schema';
+
+type State = {
+  nodes: any[];
+  selected?: any;
+  addNode: (n: any) => void;
+  updateNode: (id: string, patch: any) => void;
+  setTemplate: (t: Template) => void;
+};
+
+export const useTemplateStore = create<State>((set) => ({
+  nodes: [],
+  addNode: (n) => set((s) => ({ nodes: [...s.nodes, n] })),
+  updateNode: (id, patch) => set((s) => ({ nodes: s.nodes.map((n) => (n.id === id ? { ...n, ...patch } : n)), selected: s.selected && s.selected.id === id ? { ...s.selected, ...patch } : s.selected })),
+  setTemplate: (t) => set(() => ({ nodes: t.nodes })),
+}));

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+import flowbite from 'flowbite/plugin';
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [flowbite],
+};
+export default config;


### PR DESCRIPTION
## Summary
- scaffold Template and Record models with DRF viewsets
- add basic template builder pages and store in frontend
- provide simple dynamic form renderer

## Testing
- `python -m pytest` (fails: No module named 'django')
- `npm test` (fails: vitest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68c4a949d720832d9c139e250244d79b