### PR TITLE
Warn about unsaved changes in builder

### DIFF
--- a/frontend/src/components/builder/Builder.tsx
+++ b/frontend/src/components/builder/Builder.tsx
@@ -1,12 +1,24 @@
 'use client';
+import { useEffect } from 'react';
 import { useTemplateStore } from '@/store/useTemplateStore';
 import Canvas from './Canvas';
 import Palette from './Palette';
 import PropertyPanel from './PropertyPanel';
 
 export default function Builder({ template }: { template?: any }) {
-  const { nodes, setTemplate } = useTemplateStore();
+  const { setTemplate, dirty } = useTemplateStore();
   if (template) setTemplate(template);
+
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (!dirty) return;
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [dirty]);
+
   return (
     <div className="flex">
       <Canvas />

--- a/frontend/src/components/layout/ActiveLink.tsx
+++ b/frontend/src/components/layout/ActiveLink.tsx
@@ -3,7 +3,8 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
-import { ReactNode } from 'react';
+import { ReactNode, MouseEvent } from 'react';
+import { useTemplateStore } from '@/store/useTemplateStore';
 
 interface ActiveLinkProps {
   href: string;
@@ -15,9 +16,19 @@ interface ActiveLinkProps {
 export default function ActiveLink({ href, children, className, title }: ActiveLinkProps) {
   const pathname = usePathname();
   const isActive = pathname === href;
+  const dirty = useTemplateStore(s => s.dirty);
+  const setDirty = useTemplateStore(s => s.setDirty);
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (dirty && !window.confirm('Hay cambios sin guardar. ¿Continuar?')) {
+      e.preventDefault();
+    } else if (dirty) {
+      setDirty(false);
+    }
+  };
   return (
     <Link
       href={href}
+      onClick={handleClick}
       aria-current={isActive ? 'page' : undefined}
       className={clsx(
         'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',

--- a/frontend/src/store/useTemplateStore.test.ts
+++ b/frontend/src/store/useTemplateStore.test.ts
@@ -7,4 +7,9 @@ describe('useTemplateStore', () => {
     const k = useTemplateStore.getState().ensureUniqueKey('a');
     expect(k).toBe('a_1');
   });
+  it('sets dirty on addNode', () => {
+    useTemplateStore.setState({ nodes: [], dirty: false });
+    useTemplateStore.getState().addNode({ id: '1', key: 'a' });
+    expect(useTemplateStore.getState().dirty).toBe(true);
+  });
 });

--- a/frontend/src/store/useTemplateStore.ts
+++ b/frontend/src/store/useTemplateStore.ts
@@ -5,18 +5,26 @@ import { Template } from '@/lib/schema';
 type State = {
   nodes: any[];
   selected?: any;
+  dirty: boolean;
   addNode: (n: any) => void;
   updateNode: (id: string, patch: any) => void;
   setTemplate: (t: Template) => void;
   ensureUniqueKey: (base: string) => string;
+  setDirty: (d: boolean) => void;
 };
 
 export const useTemplateStore = create<State>((set) => ({
   nodes: [],
   selected: undefined,
-  addNode: (n) => set((s) => ({ nodes: [...s.nodes, n] })),
-  updateNode: (id, patch) => set((s) => ({ nodes: s.nodes.map((n) => (n.id === id ? { ...n, ...patch } : n)), selected: s.selected && s.selected.id === id ? { ...s.selected, ...patch } : s.selected })),
-  setTemplate: (t) => set(() => ({ nodes: t.nodes })),
+  dirty: false,
+  addNode: (n) => set((s) => ({ nodes: [...s.nodes, n], dirty: true })),
+  updateNode: (id, patch) =>
+    set((s) => ({
+      nodes: s.nodes.map((n) => (n.id === id ? { ...n, ...patch } : n)),
+      selected: s.selected && s.selected.id === id ? { ...s.selected, ...patch } : s.selected,
+      dirty: true,
+    })),
+  setTemplate: (t) => set(() => ({ nodes: t.nodes, dirty: false })),
   ensureUniqueKey: (base) => {
     let key = base;
     let i = 1;
@@ -26,4 +34,5 @@ export const useTemplateStore = create<State>((set) => ({
     }
     return key;
   },
+  setDirty: (d) => set(() => ({ dirty: d })),
 }));


### PR DESCRIPTION
## Summary
- track dirty state in builder store
- prompt on sidebar navigation when template has unsaved changes
- guard page unload for unsaved templates

## Testing
- `npm test` *(fails: vitest: not found)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68c4d728e338832dbea7348c7c69b051