### PR TITLE
feat: add component sidebar and modal to builder

### DIFF
--- a/frontend/src/components/builder/Builder.tsx
+++ b/frontend/src/components/builder/Builder.tsx
@@ -1,9 +1,10 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
 import Canvas from './Canvas';
-import Palette from '@/components/form/builder/Palette';
-import PropertyPanel from './PropertyPanel';
+import ComponentSidebar from '@/components/form/builder/ComponentSidebar';
+import FloatingToolbar from '@/components/form/builder/FloatingToolbar';
+import ComponentsModal from '@/components/form/builder/ComponentsModal';
 
 export default function Builder({ template }: { template?: any }) {
   const { setTemplate, dirty } = useBuilderStore();
@@ -19,22 +20,18 @@ export default function Builder({ template }: { template?: any }) {
     return () => window.removeEventListener('beforeunload', handler);
   }, [dirty]);
 
-
-  useEffect(() => {
-    const handler = (e: BeforeUnloadEvent) => {
-      if (!dirty) return;
-      e.preventDefault();
-      e.returnValue = '';
-    };
-    window.addEventListener('beforeunload', handler);
-    return () => window.removeEventListener('beforeunload', handler);
-  }, [dirty]);
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="flex">
-      <Canvas />
-      <Palette />
-      <PropertyPanel />
+    <div className="grid grid-cols-1 lg:grid-cols-[20rem_1fr_auto] gap-6">
+      <ComponentSidebar />
+      <div id="canvas" className="min-h-[70vh] border border-dashed rounded-2xl p-4">
+        <Canvas />
+      </div>
+      <div className="hidden lg:block">
+        <FloatingToolbar onPlus={() => setOpen(true)} />
+      </div>
+      <ComponentsModal open={open} onClose={() => setOpen(false)} />
     </div>
   );
 }

--- a/frontend/src/components/builder/Canvas.tsx
+++ b/frontend/src/components/builder/Canvas.tsx
@@ -4,7 +4,7 @@ import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
 export default function Canvas() {
   const sections = useBuilderStore(s => s.sections);
   return (
-    <div className="flex-1 border-dashed border-2 p-4 min-h-[400px]">
+    <div>
       {sections.map(sec => (
         <div key={sec.id} className="mb-4">
           {sec.children.map(n => (

--- a/frontend/src/components/form/builder/ComponentSidebar.tsx
+++ b/frontend/src/components/form/builder/ComponentSidebar.tsx
@@ -1,0 +1,65 @@
+"use client";
+import { useMemo, useState } from "react";
+import { useBuilderStore } from "@/lib/store/usePlantillaBuilderStore";
+import { newField, FieldType } from "@/lib/form-builder/factory";
+
+const BASICOS: [FieldType,string][] = [
+  ["text","Texto corto"], ["textarea","Texto largo"], ["number","Número"],
+  ["info","Texto informativo"], ["sum","Suma (readonly)"]
+];
+const SELECCION: [FieldType,string][] = [
+  ["select","Selector excluyente"], ["dropdown","Lista desplegable"],
+  ["multiselect","Selector múltiple"], ["select_with_filter","Lista con filtro"]
+];
+const AVANZADOS: [FieldType,string][] = [
+  ["date","Fecha"], ["document","Archivo"], ["phone","Teléfono"],
+  ["cuit_razon_social","CUIT y Razón social"], ["group","Grupo iterativo"]
+];
+
+export default function ComponentSidebar() {
+  const sections = useBuilderStore(s=>s.sections);
+  const selected = useBuilderStore(s=>s.selected);
+  const addField = useBuilderStore(s=>s.addField);
+  const [q, setQ] = useState("");
+
+  const sectionId = useMemo(()=>{
+    if (selected?.type==="section") return selected.id;
+    return sections?.[0]?.id;
+  }, [selected, sections]);
+
+  const handleAdd = (t: FieldType) => {
+    if (!sectionId) return window.dispatchEvent(new CustomEvent("toast",{detail:{type:"error",msg:"Creá una sección primero"}}));
+    try { addField(sectionId, t as any); }
+    catch { addField(sectionId, newField(t) as any); }
+  };
+
+  const Block = ({title, items}:{title:string; items:[FieldType,string][]}) => (
+    <div className="mb-4">
+      <h4 className="text-sm font-semibold mb-2">{title}</h4>
+      <div className="grid grid-cols-2 gap-2">
+        {items
+          .filter(([,label])=> label.toLowerCase().includes(q.toLowerCase()))
+          .map(([type,label])=>(
+          <button key={type} type="button"
+            onClick={()=>handleAdd(type)}
+            className="border rounded-xl p-2 text-left hover:bg-gray-50 focus:outline-none focus:ring">
+            <div className="text-sm font-medium">{label}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <aside className="sticky top-20 h-[calc(100vh-6rem)] overflow-auto pr-4 w-full lg:w-80">
+      <div className="mb-3">
+        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Buscar componente…"
+          className="w-full border rounded-xl p-2" />
+      </div>
+      <Block title="Básicos" items={BASICOS} />
+      <Block title="Selección" items={SELECCION} />
+      <Block title="Avanzados" items={AVANZADOS} />
+      <p className="text-xs opacity-60 mt-2">Tip: seleccioná una sección para insertar ahí.</p>
+    </aside>
+  );
+}

--- a/frontend/src/components/form/builder/ComponentsModal.tsx
+++ b/frontend/src/components/form/builder/ComponentsModal.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useEffect } from "react";
+import { newField, FieldType } from "@/lib/form-builder/factory";
+import { useBuilderStore } from "@/lib/store/usePlantillaBuilderStore";
+
+const GROUPS: Record<string,[FieldType,string][]> = {
+  "Componentes básicos": [
+    ["text","Texto corto"], ["textarea","Texto largo"],
+    ["info","Texto informativo"], ["number","Número"], ["sum","Suma (readonly)"],
+  ],
+  "Componentes avanzados": [
+    ["select_with_filter","Lista desplegable con filtro"], ["date","Fecha"],
+    ["phone","Teléfono"], ["cuit_razon_social","CUIT y razón social"], ["document","Archivo"],
+    ["select","Selector excluyente"], ["multiselect","Selector múltiple"], ["dropdown","Lista desplegable"],
+    ["group","Grupo iterativo"],
+  ],
+};
+
+export default function ComponentsModal({ open, onClose }:{open:boolean; onClose:()=>void}) {
+  const sections = useBuilderStore(s=>s.sections);
+  const selected = useBuilderStore(s=>s.selected);
+  const addField = useBuilderStore(s=>s.addField);
+  const sectionId = selected?.type==="section" ? selected.id : sections?.[0]?.id;
+
+  useEffect(()=>{
+    const onEsc = (e:KeyboardEvent)=>{ if (e.key==="Escape") onClose(); };
+    if (open) document.addEventListener("keydown", onEsc);
+    return ()=>document.removeEventListener("keydown", onEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="absolute left-1/2 top-20 -translate-x-1/2 w-[min(800px,92vw)] bg-white rounded-2xl shadow-xl p-4">
+        <h3 className="text-lg font-semibold mb-3">Componentes</h3>
+        <div className="space-y-6">
+          {Object.entries(GROUPS).map(([title, items])=>(
+            <div key={title}>
+              <h4 className="text-sm font-semibold mb-2">{title}</h4>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+                {items.map(([type, label])=>(
+                  <button key={type} type="button"
+                    onClick={()=>{
+                      if (!sectionId) return onClose();
+                      try { addField(sectionId, type as any); }
+                      catch { addField(sectionId, newField(type)); }
+                      onClose();
+                    }}
+                    className="border rounded-xl p-2 text-left hover:bg-gray-50 focus:outline-none focus:ring">
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="text-right mt-4">
+          <button onClick={onClose} className="px-3 py-2 border rounded-xl">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/form/builder/FloatingToolbar.tsx
+++ b/frontend/src/components/form/builder/FloatingToolbar.tsx
@@ -1,0 +1,15 @@
+"use client";
+export default function FloatingToolbar({ onPlus }:{ onPlus:()=>void }) {
+  return (
+    <div className="flex flex-col gap-2 p-2 rounded-2xl shadow bg-white/90 border sticky top-28">
+      <button type="button" className="w-10 h-10 grid place-items-center rounded-xl border">A</button>
+      <button type="button" className="w-10 h-10 grid place-items-center rounded-xl border">Aa</button>
+      <button type="button" className="w-10 h-10 grid place-items-center rounded-xl border">≡+</button>
+      <button type="button" aria-haspopup="dialog" aria-label="Agregar componente"
+        onClick={onPlus}
+        className="w-10 h-10 grid place-items-center rounded-xl bg-sky-100 border">
+        +
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/lib/store/usePlantillaBuilderStore.test.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.test.ts
@@ -12,4 +12,10 @@ describe('usePlantillaBuilderStore', () => {
     useBuilderStore.getState().addField('s1', 'text');
     expect(useBuilderStore.getState().dirty).toBe(true);
   });
+  it('addField accepts node objects and ensures unique key', () => {
+    useBuilderStore.setState({ sections: [{ id: 's1', children: [{ id: '1', key: 'a', type: 'text' }] }], selected: null, dirty: false });
+    useBuilderStore.getState().addField('s1', { id: '2', key: 'a', type: 'text' });
+    const children = useBuilderStore.getState().sections[0].children;
+    expect(children[1].key).toBe('a_1');
+  });
 });

--- a/frontend/src/lib/store/usePlantillaBuilderStore.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.ts
@@ -32,7 +32,7 @@ export const useBuilderStore = create<State>((set, get) => ({
     const secIdx = state.sections.findIndex(s => s.id === sectionId);
     if (secIdx < 0) return state;
     const node = typeof typeOrNode === 'string' ? newField(typeOrNode as FieldType) : typeOrNode;
-    node.key = state.ensureUniqueKey(node.key || node.type);
+    node.key = get().ensureUniqueKey(node.key || node.type);
     const sections = [...state.sections];
     const section = sections[secIdx];
     sections[secIdx] = { ...section, children: [...(section.children || []), node] };


### PR DESCRIPTION
## Summary
- add sidebar palette with searchable component groups
- support floating toolbar plus button opening components modal
- ensure builder store addField handles nodes and unique keys

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4de39fe44832daba2aeb9cd9c6ef2