### PR TITLE
feat: add field properties modal and two-column builder

### DIFF
--- a/frontend/src/components/form/builder/Builder.tsx
+++ b/frontend/src/components/form/builder/Builder.tsx
@@ -1,22 +1,22 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
-import ComponentSidebar from './ComponentSidebar';
 import Canvas from './Canvas';
-import FloatingToolbar from './FloatingToolbar';
-import ComponentsModal from './ComponentsModal';
-import PropertiesPanel from './PropertiesPanel';
+import FloatingToolbar from '@/components/form/builder/FloatingToolbar';
+import ComponentsModal from '@/components/form/builder/ComponentsModal';
+import FieldPropertiesModal from '@/components/form/builder/FieldPropertiesModal';
 
 export default function Builder({ template }: { template?: any }) {
   const { setTemplate, dirty, sections, addSection } = useBuilderStore();
-  const [open, setOpen] = useState(false);
+  const [openComponents, setOpenComponents] = useState(false);
+  const [propsId, setPropsId] = useState<string | null>(null);
 
   useEffect(() => {
     if (template) setTemplate(template);
   }, [template, setTemplate]);
 
   useEffect(() => {
-    if (!sections || sections.length === 0) addSection();
+    if (!sections?.length) addSection();
   }, [sections?.length, addSection]);
 
   useEffect(() => {
@@ -29,17 +29,24 @@ export default function Builder({ template }: { template?: any }) {
     return () => window.removeEventListener('beforeunload', handler);
   }, [dirty]);
 
+  // Listen for "builder:open-props" events
+  useEffect(() => {
+    const open = (e: any) => setPropsId(e.detail?.id || null);
+    window.addEventListener('builder:open-props', open as any);
+    return () => window.removeEventListener('builder:open-props', open as any);
+  }, []);
+
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[20rem_1fr_20rem] gap-6">
-      <ComponentSidebar />
-      <div id="canvas" className="min-h-[70vh] border border-dashed rounded-2xl p-4">
+    <div className="grid grid-cols-1 lg:grid-cols-[1fr_16rem] gap-6">
+      <div id="canvas" className="min-h-[70vh] border border-dashed rounded-2xl p-4 bg-white/40">
         <Canvas />
       </div>
-      <div className="hidden lg:flex lg:flex-col lg:gap-4">
-        <FloatingToolbar onPlus={() => setOpen(true)} />
-        <PropertiesPanel />
+      <div className="sticky top-24 h-fit">
+        <FloatingToolbar onPlus={() => setOpenComponents(true)} />
       </div>
-      <ComponentsModal open={open} onClose={() => setOpen(false)} />
+
+      <ComponentsModal open={openComponents} onClose={() => setOpenComponents(false)} />
+      <FieldPropertiesModal open={!!propsId} fieldId={propsId} onClose={() => setPropsId(null)} />
     </div>
   );
 }

--- a/frontend/src/components/form/builder/ComponentsModal.tsx
+++ b/frontend/src/components/form/builder/ComponentsModal.tsx
@@ -44,9 +44,11 @@ export default function ComponentsModal({ open, onClose }:{open:boolean; onClose
                   <button key={type} type="button"
                     onClick={()=>{
                       const sid = sectionId || addSection();
-                      try { addField(sid, type as any); }
-                      catch { addField(sid, newField(type)); }
+                      let id: string | undefined;
+                      try { id = addField(sid, type as any) as string; }
+                      catch { id = addField(sid, newField(type)) as string; }
                       onClose();
+                      if (id) window.dispatchEvent(new CustomEvent('builder:open-props',{detail:{id}}));
                     }}
                     className="border rounded-xl p-2 text-left hover:bg-gray-50 focus:outline-none focus:ring">
                     {label}

--- a/frontend/src/components/form/builder/FieldCard.tsx
+++ b/frontend/src/components/form/builder/FieldCard.tsx
@@ -97,6 +97,7 @@ export default function FieldCard({ node }:{node:any}) {
       <div className="flex items-center justify-between">
         <span className="text-xs uppercase opacity-60">{node.type}</span>
         <div className="flex gap-2">
+          <button type="button" onClick={(e)=>{e.stopPropagation(); window.dispatchEvent(new CustomEvent('builder:open-props',{detail:{id: node.id}}));}} className="text-xs px-2 py-1 border rounded">Editar</button>
           <button type="button" onClick={(e)=>{e.stopPropagation(); duplicateNode(node.id);}} className="text-xs px-2 py-1 border rounded">Duplicar</button>
           <button type="button" onClick={(e)=>{e.stopPropagation(); removeNode(node.id);}} className="text-xs px-2 py-1 border rounded">Eliminar</button>
         </div>

--- a/frontend/src/components/form/builder/FieldPropertiesModal.tsx
+++ b/frontend/src/components/form/builder/FieldPropertiesModal.tsx
@@ -1,0 +1,189 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
+
+type Props = { open: boolean; fieldId: string | null; onClose: () => void };
+
+export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) {
+  const { sections, updateNode, collectKeysByType } = useBuilderStore();
+  const node = useMemo(() => {
+    if (!fieldId) return null;
+    for (const s of sections) {
+      const direct = (s.children || []).find((n: any) => n.id === fieldId);
+      if (direct) return direct;
+      const g = (s.children || []).find((n: any) => n.type === 'group' && (n.children || []).some((c: any) => c.id === fieldId));
+      if (g) return (g.children || []).find((c: any) => c.id === fieldId);
+    }
+    return null;
+  }, [fieldId, sections]);
+
+  const [draft, setDraft] = useState<any>(null);
+  useEffect(() => { setDraft(node ? JSON.parse(JSON.stringify(node)) : null); }, [node, open]);
+  if (!open || !draft) return null;
+
+  const numKeys = collectKeysByType('number');
+
+  const Row = ({ label, children }: any) => (
+    <label className="text-sm grid grid-cols-[9rem_1fr] items-center gap-3">{/* eslint-disable-next-line */}
+      <span className="opacity-70">{label}</span><div>{children}</div>
+    </label>
+  );
+
+  const save = () => { updateNode(draft.id, draft); onClose(); };
+
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="absolute left-1/2 top-20 -translate-x-1/2 w-[min(820px,92vw)] bg-white rounded-2xl shadow-xl p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Propiedades — {draft.type.toUpperCase()}</h3>
+          <button className="px-3 py-1 border rounded-lg" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="space-y-3 max-h-[65vh] overflow-auto pr-1">
+          {/* Comunes */}
+          <Row label="Etiqueta">
+            <input className="w-full border rounded p-2" value={draft.label || ''}
+              onChange={(e) => setDraft((d: any) => ({ ...d, label: e.target.value }))} />
+          </Row>
+          <Row label="Key">
+            <input className="w-full border rounded p-2 font-mono" value={draft.key || ''}
+              onChange={(e) => setDraft((d: any) => ({ ...d, key: e.target.value }))} />
+          </Row>
+          <Row label="Obligatorio">
+            <input type="checkbox" checked={!!draft.required}
+              onChange={(e) => setDraft((d: any) => ({ ...d, required: e.target.checked }))} />
+          </Row>
+          <Row label="Subsanable">
+            <input type="checkbox" checked={!!draft.esSubsanable}
+              onChange={(e) => setDraft((d: any) => ({ ...d, esSubsanable: e.target.checked }))} />
+          </Row>
+          <Row label="Editable operador">
+            <input type="checkbox" checked={!!draft.esEditableOperador}
+              onChange={(e) => setDraft((d: any) => ({ ...d, esEditableOperador: e.target.checked }))} />
+          </Row>
+          <Row label="En grilla">
+            <input type="checkbox" checked={!!draft.seMuestraEnGrilla}
+              onChange={(e) => setDraft((d: any) => ({ ...d, seMuestraEnGrilla: e.target.checked }))} />
+          </Row>
+
+          {/* Específicas por tipo */}
+          {(draft.type === 'text' || draft.type === 'textarea') && (
+            <>
+              <Row label="Placeholder">
+                <input className="w-full border rounded p-2" value={draft.placeholder || ''}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, placeholder: e.target.value }))} />
+              </Row>
+              <Row label="Máx. largo">
+                <input type="number" className="w-full border rounded p-2" value={draft.maxLength ?? ''}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, maxLength: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+              </Row>
+              <Row label="Regex">
+                <input className="w-full border rounded p-2 font-mono" value={draft.pattern || ''}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, pattern: e.target.value }))} />
+              </Row>
+            </>
+          )}
+
+          {draft.type === 'number' && (
+            <>
+              <Row label="Mínimo">
+                <input type="number" className="w-full border rounded p-2" value={draft.min ?? ''}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, min: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+              </Row>
+              <Row label="Máximo">
+                <input type="number" className="w-full border rounded p-2" value={draft.max ?? ''}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, max: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+              </Row>
+              <Row label="Step">
+                <input type="number" className="w-full border rounded p-2" value={draft.step ?? ''}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, step: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+              </Row>
+            </>
+          )}
+
+          {['select','dropdown','multiselect','select_with_filter'].includes(draft.type) && (
+            <div className="space-y-2">
+              <div className="text-sm font-medium">Opciones</div>
+              {(draft.options || []).map((o: any, i: number) => (
+                <div key={i} className="flex gap-2">
+                  <input className="border rounded p-2 flex-1" value={o.label}
+                    onChange={(e) => {
+                      const options = [...(draft.options || [])]; options[i] = { ...o, label: e.target.value };
+                      setDraft((d: any) => ({ ...d, options }));
+                    }} />
+                  <input className="border rounded p-2 w-40 font-mono" value={o.value}
+                    onChange={(e) => {
+                      const options = [...(draft.options || [])]; options[i] = { ...o, value: e.target.value };
+                      setDraft((d: any) => ({ ...d, options }));
+                    }} />
+                  <button className="px-2 border rounded" onClick={() => {
+                    const options = [...(draft.options || [])]; options.splice(i, 1);
+                    setDraft((d: any) => ({ ...d, options }));
+                  }}>−</button>
+                </div>
+              ))}
+              <button className="px-2 py-1 border rounded"
+                onClick={() => setDraft((d: any) => ({ ...d, options: [...(d.options || []), { label: 'Opción', value: `op_${(d.options?.length || 0) + 1}` }] }))}>
+                + Agregar opción
+              </button>
+            </div>
+          )}
+
+          {draft.type === 'document' && (
+            <>
+              <Row label="Extensiones">
+                <input className="w-full border rounded p-2" placeholder=".pdf,.jpg"
+                  value={(draft.accept || []).join(',')}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, accept: e.target.value.split(',').map((s) => s.trim()).filter(Boolean) }))} />
+              </Row>
+              <Row label="Tamaño MB">
+                <input type="number" className="w-full border rounded p-2" value={draft.maxSizeMB ?? ''}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, maxSizeMB: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+              </Row>
+            </>
+          )}
+
+          {draft.type === 'sum' && (
+            <>
+              <Row label="Decimales">
+                <input type="number" className="w-full border rounded p-2" value={draft.decimals ?? 0}
+                  onChange={(e) => setDraft((d: any) => ({ ...d, decimals: Number(e.target.value) || 0 }))} />
+              </Row>
+              <div>
+                <div className="text-sm opacity-70 mb-1">Fuentes (solo números)</div>
+                <div className="flex flex-wrap gap-2">
+                  {numKeys.map((k) => {
+                    const active = (draft.sources || []).includes(k);
+                    return (
+                      <button key={k} type="button"
+                        className={`px-2 py-1 border rounded text-xs ${active ? 'bg-sky-100 border-sky-300' : ''}`}
+                        onClick={() => {
+                          const set = new Set(draft.sources || []);
+                          if (active) set.delete(k); else set.add(k);
+                          setDraft((d: any) => ({ ...d, sources: Array.from(set) }));
+                        }}>{k}</button>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
+          )}
+
+          {draft.type === 'info' && (
+            <Row label="HTML">
+              <textarea className="w-full border rounded p-2" rows={3} value={draft.html || ''}
+                onChange={(e) => setDraft((d: any) => ({ ...d, html: e.target.value }))} />
+            </Row>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button className="px-4 py-2 border rounded-lg" onClick={onClose}>Cancelar</button>
+          <button className="px-4 py-2 rounded-lg bg-sky-600 text-white" onClick={save}>Guardar</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/lib/store/usePlantillaBuilderStore.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.ts
@@ -12,7 +12,7 @@ interface State {
   selected: Selected;
   dirty: boolean;
   addSection: () => string;
-  addField: (sectionId: string, typeOrNode: FieldType | FieldNode) => void;
+  addField: (sectionId: string, typeOrNode: FieldType | FieldNode) => string | undefined;
   updateNode: (id: string, patch: any) => void;
   removeNode: (id: string) => void;
   duplicateNode: (id: string) => void;
@@ -44,19 +44,25 @@ export const useBuilderStore = create<State>((set, get) => ({
     });
     return newId;
   },
-  addField: (sectionId, typeOrNode) => set(state => {
-    const idx = state.sections.findIndex(s => s.id === sectionId);
-    if (idx < 0) return state;
+  addField: (sectionId, typeOrNode) => {
+    const sections = get().sections || [];
+    const idx = sections.findIndex((s) => s.id === sectionId);
+    if (idx < 0) return;
+
     const node = typeof typeOrNode === 'string'
       ? newField(typeOrNode as FieldType)
       : { ...typeOrNode };
-    node.id = node.id || `fld_${nanoid(6)}`;
-    node.key = state.ensureUniqueKey(node.key || node.type);
-    const sections = [...state.sections];
+    node.id = node.id ?? `fld_${crypto.randomUUID().slice(0, 6)}`;
+    node.key = get().ensureUniqueKey(node.key || node.type || 'campo');
+
     const sec = sections[idx];
-    sections[idx] = { ...sec, children: [...(sec.children || []), node] };
-    return { ...state, sections, selected: { type: 'field', id: node.id }, dirty: true };
-  }),
+    const next = [...sections];
+    next[idx] = { ...sec, children: [...(sec.children || []), node] };
+
+    set({ sections: next, selected: { type: 'field', id: node.id }, dirty: true });
+
+    return node.id;
+  },
 
   /** Busca un nodo por id y devuelve punteros: sección y posición del field */
   _locateNode(id: string) {


### PR DESCRIPTION
## Summary
- return field ID from `addField` and adjust builder to emit modal events
- redesign builder layout to two columns with floating toolbar and properties modal
- allow editing field properties via new modal and dispatch from components menu and field cards

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4eb334bec832d87b86791bece0cb1