### PR TITLE
feat(builder): enable drag and drop for sections and fields

### DIFF
--- a/frontend/src/components/form/builder/FieldCard.tsx
+++ b/frontend/src/components/form/builder/FieldCard.tsx
@@ -85,22 +85,27 @@ function MiniPreview({ node }: { node:any }) {
   }
 }
 
-export default function FieldCard({ node }:{node:any}) {
+export default function FieldCard({ node, dragHandle, readonly }:{ node:any; dragHandle?: {attributes:any; listeners:any}; readonly?:boolean }) {
   const { selected, setSelected, duplicateNode, removeNode } = useBuilderStore();
   const isSel = selected?.id === node.id;
 
   return (
     <div
-      className={`rounded-xl border bg-white p-3 space-y-2 cursor-pointer ${isSel ? 'ring-2 ring-sky-300' : 'hover:bg-gray-50'}`}
-      onClick={()=>setSelected({type:'field', id: node.id})}
+      className={`rounded-xl border bg-white p-3 space-y-2 ${readonly ? 'pointer-events-none' : 'cursor-pointer'} ${isSel ? 'ring-2 ring-sky-300' : 'hover:bg-gray-50'}`}
+      onClick={()=> !readonly && setSelected({type:'field', id: node.id})}
     >
       <div className="flex items-center justify-between">
-        <span className="text-xs uppercase opacity-60">{node.type}</span>
-        <div className="flex gap-2">
-          <button type="button" onClick={(e)=>{e.stopPropagation(); window.dispatchEvent(new CustomEvent('builder:open-props',{detail:{id: node.id}}));}} className="text-xs px-2 py-1 border rounded">Editar</button>
-          <button type="button" onClick={(e)=>{e.stopPropagation(); duplicateNode(node.id);}} className="text-xs px-2 py-1 border rounded">Duplicar</button>
-          <button type="button" onClick={(e)=>{e.stopPropagation(); removeNode(node.id);}} className="text-xs px-2 py-1 border rounded">Eliminar</button>
+        <div className="flex items-center gap-2">
+          {dragHandle && <button className="px-2 py-1 border rounded text-xs cursor-grab" {...dragHandle.attributes} {...dragHandle.listeners}>⠿</button>}
+          <span className="text-xs uppercase opacity-60">{node.type}</span>
         </div>
+        {!readonly && (
+          <div className="flex gap-2">
+            <button type="button" onClick={(e)=>{e.stopPropagation(); window.dispatchEvent(new CustomEvent('builder:open-props',{detail:{id: node.id}}));}} className="text-xs px-2 py-1 border rounded">Editar</button>
+            <button type="button" onClick={(e)=>{e.stopPropagation(); duplicateNode(node.id);}} className="text-xs px-2 py-1 border rounded">Duplicar</button>
+            <button type="button" onClick={(e)=>{e.stopPropagation(); removeNode(node.id);}} className="text-xs px-2 py-1 border rounded">Eliminar</button>
+          </div>
+        )}
       </div>
       <MiniPreview node={node} />
     </div>

--- a/frontend/src/components/form/builder/dnd/SortableField.tsx
+++ b/frontend/src/components/form/builder/dnd/SortableField.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import FieldCard from '../FieldCard';
+
+export default function SortableField({ node, sectionId }:{ node:any; sectionId:string }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: node.id,
+    data: { type: 'field', sectionId, node },
+  });
+  const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.6 : 1 };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <FieldCard node={node} dragHandle={{ attributes, listeners }} />
+    </div>
+  );
+}

--- a/frontend/src/components/form/builder/dnd/SortableSection.tsx
+++ b/frontend/src/components/form/builder/dnd/SortableSection.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useMemo } from 'react';
+import { useSortable, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import SortableField from './SortableField';
+
+export default function SortableSection({ id, section, dropId }:{ id:string; section:any; dropId:string }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    data: { type: 'section' },
+  });
+  const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.6 : 1 };
+
+  const fieldIds = useMemo(()=> (section.children || []).map((n:any)=>n.id), [section.children]);
+
+  return (
+    <section ref={setNodeRef} style={style} className="rounded-2xl border p-3 bg-white/50">
+      <header className="flex items-center justify-between rounded-xl px-3 py-2 mb-3">
+        <h3 className="font-semibold">{section.title || 'Sección'}</h3>
+        <button className="px-2 py-1 border rounded text-xs cursor-grab" {...attributes} {...listeners}>⠿</button>
+      </header>
+
+      <SortableContext items={fieldIds} strategy={verticalListSortingStrategy}>
+        <div className="space-y-2 min-h-[12px]">
+          {(section.children || []).map((node:any) => (
+            <SortableField key={node.id} node={node} sectionId={id} />
+          ))}
+          {/* zona de drop al final (para secciones vacías o soltar al final) */}
+          <div id={dropId} data-section-drop className="h-3" />
+        </div>
+      </SortableContext>
+    </section>
+  );
+}

--- a/frontend/src/lib/store/usePlantillaBuilderStore.dnd.test.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.dnd.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { useBuilderStore } from './usePlantillaBuilderStore';
+
+describe('DnD moves', () => {
+  it('moveSection reorders sections', () => {
+    useBuilderStore.setState({ sections: [{id:'s1',children:[]},{id:'s2',children:[]}], selected:null, dirty:false });
+    useBuilderStore.getState().moveSection('s2','s1');
+    expect(useBuilderStore.getState().sections.map(s=>s.id)).toEqual(['s2','s1']);
+  });
+
+  it('moveField moves across sections before over field', () => {
+    useBuilderStore.setState({
+      sections: [
+        {id:'s1', children:[{id:'a',key:'a',type:'text'},{id:'b',key:'b',type:'text'}]},
+        {id:'s2', children:[{id:'c',key:'c',type:'text'}]},
+      ],
+      selected:null, dirty:false
+    });
+    useBuilderStore.getState().moveField('a', 'c'); // mover 'a' antes de 'c' en s2
+    const [s1,s2] = useBuilderStore.getState().sections as any[];
+    expect(s1.children.map((n:any)=>n.id)).toEqual(['b']);
+    expect(s2.children.map((n:any)=>n.id)).toEqual(['a','c']);
+  });
+});


### PR DESCRIPTION
## Summary
- implement state actions to move sections and fields with dnd-kit helpers
- add canvas and sortable wrappers for drag-and-drop interactions
- expose drag handle and readonly overlay in FieldCard

## Testing
- `node node_modules/vitest/vitest.mjs run` *(fails: Cannot find package 'execa')*

------
https://chatgpt.com/codex/tasks/task_e_68c4f209a974832da434ee187ad6f8fc