### PR TITLE
feat: redesign plantillas listing

### DIFF
--- a/frontend/src/app/plantillas/page.tsx
+++ b/frontend/src/app/plantillas/page.tsx
@@ -1,25 +1,6 @@
-'use client';
-import Link from 'next/link';
-import { useQuery } from '@tanstack/react-query';
-import { PlantillasService } from '@/lib/services/plantillas';
+import PlantillasPage from '@/components/plantillas/PlantillasPage';
 
-export default function PlantillasPage() {
-  const { data } = useQuery<any>({
-    queryKey: ['plantillas'],
-    queryFn: PlantillasService.fetchPlantillas,
-  });
-  return (
-    <div>
-      <h1 className="text-2xl mb-4">Plantillas</h1>
-      <Link href="/plantillas/crear" className="border px-2 py-1">Crear</Link>
-      <ul className="mt-4 space-y-2">
-        {data?.results?.map((p: any) => (
-          <li key={p.id} className="border p-2 flex justify-between">
-            <span>{p.nombre} v{p.version}</span>
-            <Link href={`/plantillas/editar/${p.id}`} className="text-blue-600">Editar</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+export default function Page() {
+  return <PlantillasPage />;
 }
+

--- a/frontend/src/components/plantillas/DeleteConfirm.tsx
+++ b/frontend/src/components/plantillas/DeleteConfirm.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+export default function DeleteConfirm({
+  open,
+  title,
+  message,
+  onCancel,
+  onConfirm,
+  loading,
+}: {
+  open: boolean;
+  title: string;
+  message: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  loading?: boolean;
+}) {
+  if (!open) return null;
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/30" onClick={onCancel} />
+      <div className="absolute left-1/2 top-24 -translate-x-1/2 w-[min(520px,92vw)] bg-white rounded-2xl shadow-xl p-5">
+        <h4 className="text-lg font-semibold mb-2">{title}</h4>
+        <p className="text-sm opacity-80 mb-4">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button onClick={onCancel} className="px-4 py-2 rounded border">
+            Cancelar
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            className="px-4 py-2 rounded bg-red-600 text-white disabled:opacity-50"
+          >
+            {loading ? 'Eliminando…' : 'Eliminar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/plantillas/PlantillasPage.tsx
+++ b/frontend/src/components/plantillas/PlantillasPage.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { PlantillasService } from '@/lib/services/plantillas';
+import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
+import DeleteConfirm from './DeleteConfirm';
+
+type Estado = 'TODAS' | 'ACTIVO' | 'INACTIVO';
+const cols = 'grid grid-cols-[1fr_120px_160px_120px_40px] gap-4 items-center';
+
+export default function PlantillasPage() {
+  const router = useRouter();
+  const qc = useQueryClient();
+  const [q, setQ] = useState('');
+  const dq = useDebouncedValue(q, 300);
+  const [estado, setEstado] = useState<Estado>('TODAS');
+  const [page, setPage] = useState(1);
+  const [toDelete, setToDelete] = useState<{ id: string; nombre: string } | null>(
+    null
+  );
+
+  const { data, isLoading, isFetching } = useQuery({
+    queryKey: ['plantillas', { dq, estado, page }],
+    queryFn: () =>
+      PlantillasService.fetchPlantillas({
+        search: dq || undefined,
+        estado: estado === 'TODAS' ? undefined : estado,
+        page,
+        page_size: 10,
+      }),
+    keepPreviousData: true,
+  });
+
+  const del = useMutation({
+    mutationFn: (id: string) => PlantillasService.deletePlantilla(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['plantillas'] });
+      setToDelete(null);
+    },
+  });
+
+  const duplicar = useMutation({
+    mutationFn: async (tpl: any) => {
+      const nombre = `${tpl.nombre} (copia)`;
+      return PlantillasService.savePlantilla({
+        nombre,
+        descripcion: tpl.descripcion || null,
+        schema: tpl.schema,
+      });
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['plantillas'] }),
+  });
+
+  const results = data?.results ?? [];
+  const total = data?.count ?? results.length;
+  const totalPages = Math.max(1, Math.ceil(total / 10));
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Plantillas</h1>
+          <p className="text-sm opacity-70">
+            Diseñá, previsualizá y administrá las plantillas de legajos.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => router.push('/plantillas/crear')}
+            className="px-4 py-2 rounded-xl bg-sky-600 text-white hover:brightness-110"
+          >
+            + Crear plantilla
+          </button>
+        </div>
+      </div>
+
+      {/* Filtros */}
+      <div className="flex flex-col md:flex-row gap-3 items-stretch md:items-center">
+        <div className="relative flex-1">
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Buscar por nombre…"
+            className="w-full border rounded-xl pl-9 pr-3 py-2"
+          />
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 opacity-60">
+            🔎
+          </span>
+        </div>
+        <select
+          value={estado}
+          onChange={(e) => {
+            setEstado(e.target.value as Estado);
+            setPage(1);
+          }}
+          className="border rounded-xl px-3 py-2 w-full md:w-48"
+        >
+          <option value="TODAS">Todas</option>
+          <option value="ACTIVO">Activas</option>
+          <option value="INACTIVO">Inactivas</option>
+        </select>
+      </div>
+
+      {/* Tabla / Empty / Loader */}
+      <div className="rounded-2xl border bg-white overflow-hidden">
+        <div className={`px-4 py-3 text-xs uppercase tracking-wide bg-gray-50 ${cols}`}>
+          <div>Nombre</div>
+          <div>Versión</div>
+          <div>Actualizado</div>
+          <div>Estado</div>
+          <div></div>
+        </div>
+
+        {isLoading ? (
+          <SkeletonRows />
+        ) : results.length === 0 ? (
+          <EmptyState onCreate={() => router.push('/plantillas/crear')} />
+        ) : (
+          <div className="divide-y">
+            {results.map((p: any) => (
+              <Row
+                key={p.id}
+                data={p}
+                onEditar={() => router.push(`/plantillas/editar/${p.id}`)}
+                onPreview={() => {
+                  try {
+                    localStorage.setItem(
+                      'nodo.plantilla.preview',
+                      JSON.stringify(p.schema)
+                    );
+                  } catch {}
+                  window.open('/plantillas/previsualizacion', '_blank');
+                }}
+                onUsar={() => router.push(`/legajos/nuevo?plantillaId=${p.id}`)}
+                onDuplicar={() => duplicar.mutate(p)}
+                onEliminar={() => setToDelete({ id: p.id, nombre: p.nombre })}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer paginación */}
+      <div className="flex items-center justify-between text-sm">
+        <div className="opacity-70">
+          {isFetching ? 'Actualizando…' : `${total} resultados`}
+        </div>
+        <div className="flex gap-2">
+          <button
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            className="px-3 py-1 rounded border disabled:opacity-50"
+          >
+            Anterior
+          </button>
+          <div className="px-2 py-1">
+            {page} / {totalPages}
+          </div>
+          <button
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            className="px-3 py-1 rounded border disabled:opacity-50"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
+
+      {/* Modal borrar */}
+      <DeleteConfirm
+        open={!!toDelete}
+        title="Eliminar plantilla"
+        message={`¿Eliminar "${toDelete?.nombre}"? Esto la desactivará para nuevos legajos.`}
+        onCancel={() => setToDelete(null)}
+        onConfirm={() => toDelete && del.mutate(toDelete.id)}
+        loading={del.isPending}
+      />
+    </div>
+  );
+}
+
+function Row({
+  data,
+  onEditar,
+  onPreview,
+  onUsar,
+  onDuplicar,
+  onEliminar,
+}: {
+  data: any;
+  onEditar: () => void;
+  onPreview: () => void;
+  onUsar: () => void;
+  onDuplicar: () => void;
+  onEliminar: () => void;
+}) {
+  const fecha = formatDate(
+    data.updated_at || data.updatedAt || data.updated || data.created_at
+  );
+  const estado = String(data.estado || 'ACTIVO').toUpperCase();
+  return (
+    <div className={`px-4 py-3 ${cols}`}>
+      <div className="flex items-center gap-2">
+        <div className="w-8 h-8 grid place-items-center rounded-lg bg-sky-100">
+          📄
+        </div>
+        <div>
+          <div className="font-medium">{data.nombre}</div>
+          <div className="text-xs opacity-60">{data.descripcion || '—'}</div>
+          <div className="mt-2 flex gap-2">
+            <button onClick={onEditar} className="text-xs px-2 py-1 rounded border">
+              Editar
+            </button>
+            <button onClick={onPreview} className="text-xs px-2 py-1 rounded border">
+              Previsualizar
+            </button>
+            <button onClick={onUsar} className="text-xs px-2 py-1 rounded border">
+              Usar
+            </button>
+            <button onClick={onDuplicar} className="text-xs px-2 py-1 rounded border">
+              Duplicar
+            </button>
+            <button
+              onClick={onEliminar}
+              className="text-xs px-2 py-1 rounded border text-red-600"
+            >
+              Eliminar
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="text-sm tabular-nums">v{data.version ?? 1}</div>
+      <div className="text-sm">{fecha}</div>
+      <div>
+        <span
+          className={`px-2 py-1 rounded-full text-xs ${
+            estado === 'ACTIVO'
+              ? 'bg-emerald-100 text-emerald-800'
+              : 'bg-gray-200 text-gray-700'
+          }`}
+        >
+          {estado}
+        </span>
+      </div>
+      <div></div>
+    </div>
+  );
+}
+
+function SkeletonRows() {
+  return (
+    <div className="divide-y">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="px-4 py-3 animate-pulse grid grid-cols-[1fr_120px_160px_120px_40px] gap-4 items-center"
+        >
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 rounded-lg bg-slate-200" />
+            <div className="space-y-2">
+              <div className="h-3 w-40 bg-slate-200 rounded" />
+              <div className="h-2 w-24 bg-slate-200 rounded" />
+            </div>
+          </div>
+          <div className="h-3 w-8 bg-slate-200 rounded" />
+          <div className="h-3 w-24 bg-slate-200 rounded" />
+          <div className="h-6 w-20 bg-slate-200 rounded-full" />
+          <div />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="px-6 py-12 text-center">
+      <div className="mx-auto mb-3 w-14 h-14 rounded-2xl grid place-items-center bg-sky-100">
+        ✨
+      </div>
+      <h3 className="text-lg font-semibold mb-1">No hay plantillas</h3>
+      <p className="text-sm opacity-70 mb-4">
+        Crea tu primera plantilla para empezar a cargar legajos.
+      </p>
+      <button
+        onClick={onCreate}
+        className="px-4 py-2 rounded-xl bg-sky-600 text-white"
+      >
+        + Crear plantilla
+      </button>
+    </div>
+  );
+}
+
+function formatDate(iso?: string) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '—';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()} ${pad(
+    d.getHours()
+  )}:${pad(d.getMinutes())}`;
+}
+

--- a/frontend/src/lib/hooks/useDebouncedValue.ts
+++ b/frontend/src/lib/hooks/useDebouncedValue.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, ms = 300) {
+  const [v, setV] = useState(value);
+
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+
+  return v;
+}
+

--- a/frontend/src/lib/services/plantillas.ts
+++ b/frontend/src/lib/services/plantillas.ts
@@ -102,4 +102,9 @@ export const PlantillasService = {
 
   updatePlantilla: (id: string, payload: any) =>
     postPutWithFallback('PUT', `/plantillas/${id}`, `/formularios/${id}`, payload),
+
+  deletePlantilla: (id: string) =>
+    apiFetch(`/plantillas/${id}`, { method: 'DELETE' }).catch(() =>
+      apiFetch(`/formularios/${id}`, { method: 'DELETE' })
+    ),
 };


### PR DESCRIPTION
## Summary
- add delete support to PlantillasService
- implement debounced search hook and plantillas listing UI
- add delete confirmation modal

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4f3338c28832d8f78151a0c3368d7