### PR TITLE
feat: refine builder drag behaviour

### DIFF
--- a/frontend/src/components/form/builder/Builder.tsx
+++ b/frontend/src/components/form/builder/Builder.tsx
@@ -8,7 +8,7 @@ import BuilderHeader from './BuilderHeader';
 import FieldPropertiesModal from './FieldPropertiesModal';
 
 export default function Builder({ template }: { template?: any }) {
-  const { setTemplate, dirty, sections, addSection, selected } = useBuilderStore();
+  const { setTemplate, dirty, sections, addSection } = useBuilderStore();
 
   const [openComponents, setOpenComponents] = useState(false);
   const [propsId, setPropsId] = useState<string | null>(null);
@@ -20,11 +20,6 @@ export default function Builder({ template }: { template?: any }) {
   useEffect(() => {
     if (!sections?.length) addSection();
   }, [sections?.length, addSection]);
-
-  // Abrir modal de propiedades si hay un campo seleccionado
-  useEffect(() => {
-    if (selected?.type === 'field') setPropsId(selected.id);
-  }, [selected]);
 
   // Confirmación al salir con cambios sin guardar
   useEffect(() => {

--- a/frontend/src/components/form/builder/Canvas.tsx
+++ b/frontend/src/components/form/builder/Canvas.tsx
@@ -1,44 +1,70 @@
 'use client';
-import { DndContext, DragEndEvent, DragOverlay, MouseSensor, TouchSensor, useSensor, useSensors, closestCorners } from '@dnd-kit/core';
+import {
+  DndContext, DragEndEvent, DragOverlay,
+  MouseSensor, TouchSensor, useSensor, useSensors, closestCorners
+} from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useMemo, useState } from 'react';
 import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
 import SortableSection from './dnd/SortableSection';
 import FieldCard from './FieldCard';
 
-const DROP_PREFIX = 'drop-'; // droppable vacío al final de cada sección
+const DROP_PREFIX = 'drop-';
 
 export default function Canvas() {
   const { sections, moveSection, moveField } = useBuilderStore();
-  const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
-  const [activeField, setActiveField] = useState<any>(null);
 
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 120, tolerance: 6 } })
+  );
+
+  const [activeField, setActiveField] = useState<any>(null);
   const sectionIds = useMemo(() => sections.map((s: any) => s.id), [sections]);
+
+  const targetSectionFromOver = (over: any): string | null => {
+    if (!over) return null;
+    const id = String(over.id);
+    const data = over.data?.current;
+    if (data?.type === 'section') return String(over.id);
+    if (data?.type === 'field') return data.sectionId || null;
+    if (data?.type === 'section-drop') return data.sectionId || null;
+    if (id.startsWith(DROP_PREFIX)) return id.replace(DROP_PREFIX, '');
+    return null;
+  };
 
   const onDragEnd = (e: DragEndEvent) => {
     const { active, over } = e;
-    if (!over) return;
+    if (!over) { setActiveField(null); return; }
     const activeType = active.data.current?.type as 'section' | 'field' | undefined;
-    const overId = String(over.id);
+
     if (activeType === 'section') {
-      moveSection(String(active.id), overId);
+      const toSection = targetSectionFromOver(over);
+      if (toSection) moveSection(String(active.id), toSection);
     } else if (activeType === 'field') {
-      // si over es "drop-<secId>", mover al final de esa sección
-      if (overId.startsWith(DROP_PREFIX)) {
-        const toSec = overId.replace(DROP_PREFIX, '');
-        moveField(String(active.id), null, toSec);
+      const overData = over.data.current;
+      if (overData?.type === 'section-drop') {
+        moveField(String(active.id), null, overData.sectionId);
+      } else if (overData?.type === 'section') {
+        moveField(String(active.id), null, String(over.id)); // al final de esa sección
       } else {
-        // mover antes del campo "over"; si es otra sección, se detecta adentro de moveField
-        moveField(String(active.id), overId);
+        moveField(String(active.id), String(over.id)); // antes del campo over
       }
     }
     setActiveField(null);
   };
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCorners}
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
       onDragEnd={onDragEnd}
-      onDragStart={(e)=>{ if(e.active.data.current?.type==='field'){ setActiveField(e.active.data.current?.node);} }}>
+      onDragStart={(e) => {
+        if (e.active.data.current?.type === 'field') {
+          setActiveField(e.active.data.current?.node);
+        }
+      }}
+    >
       <SortableContext items={sectionIds} strategy={verticalListSortingStrategy}>
         <div className="space-y-6">
           {sections.map((sec: any) => (

--- a/frontend/src/components/form/builder/FieldCard.tsx
+++ b/frontend/src/components/form/builder/FieldCard.tsx
@@ -96,7 +96,17 @@ export default function FieldCard({ node, dragHandle, readonly }:{ node:any; dra
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          {dragHandle && <button className="px-2 py-1 border rounded text-xs cursor-grab" {...dragHandle.attributes} {...dragHandle.listeners}>⠿</button>}
+          {dragHandle && (
+            <button
+              className="px-2 py-1 border rounded text-xs cursor-grab"
+              {...dragHandle.attributes}
+              {...dragHandle.listeners}
+              onMouseDownCapture={(e)=>e.stopPropagation()}
+              onPointerDownCapture={(e)=>e.stopPropagation()}
+            >
+              ⠿
+            </button>
+          )}
           <span className="text-xs uppercase opacity-60">{node.type}</span>
         </div>
         {!readonly && (

--- a/frontend/src/components/form/builder/dnd/SectionEndDrop.tsx
+++ b/frontend/src/components/form/builder/dnd/SectionEndDrop.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { useDroppable } from '@dnd-kit/core';
+
+export default function SectionEndDrop({ id, sectionId }:{ id:string; sectionId:string }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id,
+    data: { type: 'section-drop', sectionId },
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`h-3 rounded ${isOver ? 'bg-sky-200/60' : ''}`}
+      aria-hidden
+    />
+  );
+}

--- a/frontend/src/components/form/builder/dnd/SortableSection.tsx
+++ b/frontend/src/components/form/builder/dnd/SortableSection.tsx
@@ -3,15 +3,17 @@ import { useMemo } from 'react';
 import { useSortable, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import SortableField from './SortableField';
+import SectionEndDrop from './SectionEndDrop';
 
-export default function SortableSection({ id, section, dropId }:{ id:string; section:any; dropId:string }) {
+export default function SortableSection({ id, section, dropId }:{
+  id:string; section:any; dropId:string;
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
     data: { type: 'section' },
   });
   const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.6 : 1 };
-
-  const fieldIds = useMemo(()=> (section.children || []).map((n:any)=>n.id), [section.children]);
+  const fieldIds = useMemo(() => (section.children || []).map((n:any) => n.id), [section.children]);
 
   return (
     <section ref={setNodeRef} style={style} className="rounded-2xl border p-3 bg-white/50">
@@ -25,8 +27,8 @@ export default function SortableSection({ id, section, dropId }:{ id:string; sec
           {(section.children || []).map((node:any) => (
             <SortableField key={node.id} node={node} sectionId={id} />
           ))}
-          {/* zona de drop al final (para secciones vacías o soltar al final) */}
-          <div id={dropId} data-section-drop className="h-3" />
+          {/* droppable al final */}
+          <SectionEndDrop id={dropId} sectionId={id} />
         </div>
       </SortableContext>
     </section>


### PR DESCRIPTION
## Summary
- improve DnD handling to allow moving sections with fields and drop zones at section end
- block drag handle click propagation and avoid auto-opening properties modal

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f43d19f4832da5cff05eae936a0e