### PR TITLE
feat(builder): add CRUD for form sections

### DIFF
--- a/frontend/src/components/form/builder/Builder.tsx
+++ b/frontend/src/components/form/builder/Builder.tsx
@@ -48,6 +48,12 @@ export default function Builder({ template }: { template?: any }) {
     };
   }, []);
 
+  useEffect(() => {
+    const open = () => setOpenComponents(true);
+    window.addEventListener('builder:open-components', open);
+    return () => window.removeEventListener('builder:open-components', open);
+  }, []);
+
   return (
     <>
       <BuilderHeader />

--- a/frontend/src/components/form/builder/Canvas.tsx
+++ b/frontend/src/components/form/builder/Canvas.tsx
@@ -9,7 +9,7 @@ import FieldCard from './FieldCard';
 const DROP_PREFIX = 'drop-'; // droppable vacío al final de cada sección
 
 export default function Canvas() {
-  const { sections, moveSection, moveField } = useBuilderStore();
+  const { sections, moveSection, moveField, addSection } = useBuilderStore();
   const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
   const [activeField, setActiveField] = useState<any>(null);
 
@@ -39,6 +39,20 @@ export default function Canvas() {
     <DndContext sensors={sensors} collisionDetection={closestCorners}
       onDragEnd={onDragEnd}
       onDragStart={(e)=>{ if(e.active.data.current?.type==='field'){ setActiveField(e.active.data.current?.node);} }}>
+      {/* Barra para crear secciones */}
+      <div className="mb-4">
+        <button
+          type="button"
+          onClick={() => {
+            addSection();
+            setTimeout(() => window.dispatchEvent(new Event('builder:open-components')), 0);
+          }}
+          className="px-3 py-2 rounded-xl border bg-white hover:bg-gray-50"
+        >
+          + Agregar sección
+        </button>
+      </div>
+
       <SortableContext items={sectionIds} strategy={verticalListSortingStrategy}>
         <div className="space-y-6">
           {sections.map((sec: any) => (

--- a/frontend/src/components/form/builder/dnd/SectionEndDrop.tsx
+++ b/frontend/src/components/form/builder/dnd/SectionEndDrop.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { useDroppable } from '@dnd-kit/core';
+
+export default function SectionEndDrop({ id, sectionId }:{ id:string; sectionId:string }) {
+  const { setNodeRef, isOver } = useDroppable({ id, data: { sectionId } });
+  return <div ref={setNodeRef} id={id} data-section-drop className={`h-3 ${isOver ? 'bg-sky-100' : ''}`} />;
+}

--- a/frontend/src/components/form/builder/dnd/SortableSection.tsx
+++ b/frontend/src/components/form/builder/dnd/SortableSection.tsx
@@ -2,22 +2,53 @@
 import { useMemo } from 'react';
 import { useSortable, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
 import SortableField from './SortableField';
+import SectionEndDrop from './SectionEndDrop';
 
-export default function SortableSection({ id, section, dropId }:{ id:string; section:any; dropId:string }) {
+export default function SortableSection({ id, section, dropId }:{
+  id:string; section:any; dropId:string;
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id,
-    data: { type: 'section' },
+    id, data: { type: 'section' },
   });
   const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.6 : 1 };
+
+  const { selected, setSelected, updateSection, duplicateSection, removeSection } = useBuilderStore();
+  const isSel = selected?.type === 'section' && selected.id === id;
 
   const fieldIds = useMemo(()=> (section.children || []).map((n:any)=>n.id), [section.children]);
 
   return (
     <section ref={setNodeRef} style={style} className="rounded-2xl border p-3 bg-white/50">
-      <header className="flex items-center justify-between rounded-xl px-3 py-2 mb-3">
-        <h3 className="font-semibold">{section.title || 'Sección'}</h3>
-        <button className="px-2 py-1 border rounded text-xs cursor-grab" {...attributes} {...listeners}>⠿</button>
+      <header
+        className={`flex items-center justify-between rounded-xl px-3 py-2 mb-3 ${isSel ? 'ring-2 ring-sky-300' : ''}`}
+        onClick={()=>setSelected({type:'section', id})}
+      >
+        <div className="flex items-center gap-2">
+          <button className="px-2 py-1 border rounded text-xs cursor-grab" {...attributes} {...listeners}>⠿</button>
+          {isSel ? (
+            <input
+              className="border rounded px-2 py-1"
+              value={section.title || ''}
+              onChange={(e)=>updateSection(id, { title: e.target.value })}
+            />
+          ) : (
+            <h3 className="font-semibold">{section.title || 'Sección'}</h3>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={(e)=>{ e.stopPropagation(); duplicateSection(id); }}
+            className="text-xs px-2 py-1 border rounded"
+          >Duplicar</button>
+          <button
+            type="button"
+            onClick={(e)=>{ e.stopPropagation(); if (confirm('¿Eliminar sección?')) removeSection(id); }}
+            className="text-xs px-2 py-1 border rounded text-red-600"
+          >Eliminar</button>
+        </div>
       </header>
 
       <SortableContext items={fieldIds} strategy={verticalListSortingStrategy}>
@@ -25,8 +56,7 @@ export default function SortableSection({ id, section, dropId }:{ id:string; sec
           {(section.children || []).map((node:any) => (
             <SortableField key={node.id} node={node} sectionId={id} />
           ))}
-          {/* zona de drop al final (para secciones vacías o soltar al final) */}
-          <div id={dropId} data-section-drop className="h-3" />
+          <SectionEndDrop id={dropId} sectionId={id} />
         </div>
       </SortableContext>
     </section>

--- a/frontend/src/lib/store/usePlantillaBuilderStore.test.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.test.ts
@@ -43,4 +43,39 @@ describe('usePlantillaBuilderStore', () => {
     expect(state.sections[0].id).toBe(id);
     expect(state.selected).toEqual({ type: 'section', id });
   });
+
+  it('updateSection changes title and marks dirty', () => {
+    useBuilderStore.setState({ sections: [{ id: 's1', title: 'Old', children: [] }], selected: null, dirty: false });
+    useBuilderStore.getState().updateSection('s1', { title: 'New' });
+    const state = useBuilderStore.getState();
+    expect(state.sections[0].title).toBe('New');
+    expect(state.dirty).toBe(true);
+  });
+
+  it('duplicateSection clones with new ids and keys', () => {
+    useBuilderStore.setState({
+      sections: [{ id: 's1', title: 'Sec', children: [{ id: 'f1', type: 'text', key: 'a' }] }],
+      selected: null,
+      dirty: false,
+    });
+    useBuilderStore.getState().duplicateSection('s1');
+    const state = useBuilderStore.getState();
+    expect(state.sections.length).toBe(2);
+    const [orig, copy] = state.sections as any[];
+    expect(copy.id).not.toBe(orig.id);
+    expect(copy.children[0].id).not.toBe(orig.children[0].id);
+    expect(copy.children[0].key).not.toBe(orig.children[0].key);
+    expect(state.selected).toEqual({ type: 'section', id: copy.id });
+    expect(state.dirty).toBe(true);
+  });
+
+  it('removeSection keeps one section', () => {
+    useBuilderStore.setState({ sections: [{ id: 's1', title: 'Sec1', children: [] }], selected: null, dirty: false });
+    useBuilderStore.getState().removeSection('s1');
+    const state = useBuilderStore.getState();
+    expect(state.sections.length).toBe(1);
+    expect(state.sections[0].id).not.toBe('s1');
+    expect(state.selected).toEqual({ type: 'section', id: state.sections[0].id });
+    expect(state.dirty).toBe(true);
+  });
 });

--- a/frontend/src/lib/store/usePlantillaBuilderStore.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.ts
@@ -1,6 +1,5 @@
 'use client';
 import { create } from 'zustand';
-import { nanoid } from 'nanoid';
 import { newField, FieldType } from '@/lib/form-builder/factory';
 import { arrayMove } from '@dnd-kit/sortable';
 
@@ -24,6 +23,9 @@ interface State {
   buildSchema: () => any;
 
   addSection: () => string;
+  updateSection: (id: string, patch: Partial<any>) => void;
+  duplicateSection: (id: string) => void;
+  removeSection: (id: string) => void;
   addField: (sectionId: string, typeOrNode: FieldType | FieldNode) => string | undefined;
   updateNode: (id: string, patch: any) => void;
   removeNode: (id: string) => void;
@@ -47,21 +49,69 @@ export const useBuilderStore = create<State>((set, get) => ({
   version: 1,
   descripcion: null,
   addSection: () => {
-    let newId = '';
-    set(state => {
-      const id = `sec_${nanoid(6)}`;
-      const title = `Sección ${state.sections.length + 1}`;
-      const section = { type: 'section', id, title, collapsed: false, children: [] as any[] };
-      newId = id;
+    const n = (get().sections?.length || 0) + 1;
+    const id = `sec_${crypto.randomUUID().slice(0, 6)}`;
+    const section = { type: 'section', id, title: `Sección ${n}`, children: [] as any[] };
+    set((s) => ({
+      sections: [...(s.sections || []), section],
+      selected: { type: 'section', id },
+      dirty: true,
+    }));
+    return id;
+  },
+
+  updateSection: (id, patch) => set((state) => {
+    const sections = (state.sections || []).map((s: any) =>
+      s.id === id ? { ...s, ...patch } : s
+    );
+    return { ...state, sections, dirty: true };
+  }),
+
+  duplicateSection: (id) => set((state) => {
+    const idx = (state.sections || []).findIndex((s: any) => s.id === id);
+    if (idx < 0) return state;
+    const deep = (o: any) => JSON.parse(JSON.stringify(o));
+    const clone = deep(state.sections[idx]);
+    clone.id = `sec_${crypto.randomUUID().slice(0, 6)}`;
+    clone.title = `${clone.title || 'Sección'} (copia)`;
+    const ensure = state.ensureUniqueKey;
+    clone.children = (clone.children || []).map((n: any) => {
+      const c = deep(n);
+      c.id = `fld_${crypto.randomUUID().slice(0, 6)}`;
+      if (c.key) c.key = ensure(c.key);
+      if (c.children)
+        c.children = c.children.map((nn: any) => {
+          const cc = deep(nn);
+          cc.id = `fld_${crypto.randomUUID().slice(0, 6)}`;
+          if (cc.key) cc.key = ensure(cc.key);
+          return cc;
+        });
+      return c;
+    });
+    const sections = [...state.sections];
+    sections.splice(idx + 1, 0, clone);
+    return {
+      ...state,
+      sections,
+      selected: { type: 'section', id: clone.id },
+      dirty: true,
+    };
+  }),
+
+  removeSection: (id) => set((state) => {
+    const sections = (state.sections || []).filter((s: any) => s.id !== id);
+    if (sections.length === 0) {
+      const fallbackId = `sec_${crypto.randomUUID().slice(0, 6)}`;
+      sections.push({ type: 'section', id: fallbackId, title: 'Sección 1', children: [] });
       return {
         ...state,
-        sections: [...state.sections, section],
-        selected: { type: 'section', id },
+        sections,
+        selected: { type: 'section', id: fallbackId },
         dirty: true,
       };
-    });
-    return newId;
-  },
+    }
+    return { ...state, sections, selected: null, dirty: true };
+  }),
   addField: (sectionId, typeOrNode) => {
     const sections = get().sections || [];
     const idx = sections.findIndex((s) => s.id === sectionId);


### PR DESCRIPTION
## Summary
- add builder store actions to add, update, duplicate and remove sections
- allow creating sections from canvas and manage titles, duplication and removal in UI
- open components modal after adding a section and keep drag end drop support

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f4ee1554832dbe3820274d96d6cf