### PR TITLE
feat: improve http client and backend origin config

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -97,18 +97,16 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3008")
-
 
 CORS_ALLOWED_ORIGINS = [
-    FRONTEND_URL,
+    "http://localhost:3000",
     "http://localhost:3008",
 ]
 
 CORS_ALLOW_CREDENTIALS = True
 
 CSRF_TRUSTED_ORIGINS = [
-    FRONTEND_URL,
+    "http://localhost:3000",
     "http://localhost:3008",
 ]
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_URL=http://backend:8000
+NEXT_PUBLIC_API_BASE=http://localhost:8000/api

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,14 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  async rewrites() {
-    return [
-      {
-        source: '/api/:path*',
-        destination: 'http://localhost:8000/api/:path*',
-      },
-    ];
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- harden frontend http client with timeout, better errors, and backend->localhost fallback
- simplify PlantillasService and clean up Next.js config
- explicitly allow localhost origins for Django CORS/CSRF

## Testing
- `npm test` *(fails: vitest not found)*
- `python -m pytest` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68c4f9cd9c3c832da412be29c3977559