### PR TITLE
feat(builder): drag and drop fixes

### DIFF
--- a/frontend/src/lib/store/usePlantillaBuilderStore.dnd.test.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.dnd.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { useBuilderStore } from './usePlantillaBuilderStore';
 
 describe('DnD moves', () => {
+  beforeEach(() => {
+    useBuilderStore.setState({ sections: [], selected: null, dirty: false });
+  });
+
   it('moveSection reorders sections', () => {
     useBuilderStore.setState({ sections: [{id:'s1',children:[]},{id:'s2',children:[]}], selected:null, dirty:false });
     useBuilderStore.getState().moveSection('s2','s1');
@@ -16,9 +20,49 @@ describe('DnD moves', () => {
       ],
       selected:null, dirty:false
     });
-    useBuilderStore.getState().moveField('a', 'c'); // mover 'a' antes de 'c' en s2
+    useBuilderStore.getState().moveField('a', 'c');
     const [s1,s2] = useBuilderStore.getState().sections as any[];
     expect(s1.children.map((n:any)=>n.id)).toEqual(['b']);
     expect(s2.children.map((n:any)=>n.id)).toEqual(['a','c']);
+  });
+
+  it('moveField with toSectionId inserts at end', () => {
+    useBuilderStore.setState({
+      sections: [
+        {id:'s1', children:[{id:'a',key:'a',type:'text'}]},
+        {id:'s2', children:[{id:'b',key:'b',type:'text'}]},
+      ],
+      selected:null, dirty:false
+    });
+    useBuilderStore.getState().moveField('a', null, 's2');
+    const [,s2] = useBuilderStore.getState().sections as any[];
+    expect(s2.children.map((n:any)=>n.id)).toEqual(['b','a']);
+  });
+
+  it('moveField does not lose or duplicate fields', () => {
+    useBuilderStore.setState({
+      sections: [
+        {id:'s1', children:[{id:'a',key:'a',type:'text'},{id:'b',key:'b',type:'text'}]},
+        {id:'s2', children:[{id:'c',key:'c',type:'text'}]},
+      ],
+      selected:null, dirty:false
+    });
+    useBuilderStore.getState().moveField('a', 'c');
+    const ids = useBuilderStore.getState().sections.flatMap((s:any)=>s.children.map((n:any)=>n.id));
+    expect(ids.sort()).toEqual(['a','b','c']);
+  });
+
+  it('moveField updates selected and dirty', () => {
+    useBuilderStore.setState({
+      sections: [
+        {id:'s1', children:[{id:'a',key:'a',type:'text'}]},
+        {id:'s2', children:[{id:'b',key:'b',type:'text'}]},
+      ],
+      selected:null, dirty:false
+    });
+    useBuilderStore.getState().moveField('a', null, 's2');
+    const st = useBuilderStore.getState();
+    expect(st.dirty).toBe(true);
+    expect(st.selected).toEqual({type:'field', id:'a'});
   });
 });

--- a/frontend/src/lib/store/usePlantillaBuilderStore.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.ts
@@ -3,12 +3,25 @@ import { create } from 'zustand';
 import { newField, FieldType } from '@/lib/form-builder/factory';
 import { arrayMove } from '@dnd-kit/sortable';
 
-type FieldNode = any;
-interface Section { id: string; title?: string; children: FieldNode[]; }
+export type FieldNode = {
+  id: string;
+  type: string;
+  key?: string;
+  label?: string;
+  [k: string]: any;
+};
+
+export type SectionNode = {
+  id: string;
+  title?: string;
+  children: FieldNode[];
+  [k: string]: any;
+};
+
 type Selected = { type: 'section' | 'field'; id: string } | null;
 
-interface State {
-  sections: Section[];
+export interface BuilderState {
+  sections: SectionNode[];
   selected: Selected;
   dirty: boolean;
 
@@ -41,7 +54,7 @@ interface State {
   _locateNode: (id: string) => any;
 }
 
-export const useBuilderStore = create<State>((set, get) => ({
+export const useBuilderStore = create<BuilderState>((set, get) => ({
   sections: [],
   selected: null,
   dirty: false,


### PR DESCRIPTION
## Summary
- add typed builder store and immutable move helpers
- cover drag and drop section/field moves with tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5820f5d78832d96bdf33482ab04be