### PR TITLE
feat: improve template builder navigation and listing

### DIFF
--- a/frontend/src/components/form/builder/Builder.tsx
+++ b/frontend/src/components/form/builder/Builder.tsx
@@ -18,7 +18,11 @@ export default function Builder({ template }: { template?: any }) {
   }, [template, setTemplate]);
 
   useEffect(() => {
-    if (!sections?.length) addSection();
+    if (!sections?.length) {
+      addSection();
+      // no marcar cambios por la sección inicial
+      setTimeout(() => useBuilderStore.getState().setDirty(false), 0);
+    }
   }, [sections?.length, addSection]);
 
   // Confirmación al salir con cambios sin guardar

--- a/frontend/src/components/form/builder/BuilderHeader.tsx
+++ b/frontend/src/components/form/builder/BuilderHeader.tsx
@@ -1,31 +1,42 @@
 'use client';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
 import { PlantillasService } from '@/lib/services/plantillas';
 import { serializeTemplateSchema } from '@/lib/serializeTemplate';
 
 export default function BuilderHeader() {
-  const { sections, validateAll } = useBuilderStore();
-  const [nombre, setNombre] = useState('');
+  const router = useRouter();
+  const { sections, validateAll, nombre, setNombre, resetDirty } = useBuilderStore();
   const [saving, setSaving] = useState(false);
+
+  const onBack = () => router.push('/plantillas');
 
   const onSave = async () => {
     const errs = validateAll();
     if (!nombre.trim()) errs.unshift({ code: 'NAME', message: 'Debes ingresar un nombre.' });
-
     if (errs.length) {
       alert('Revisá el formulario:\n- ' + errs.map(e => e.message).join('\n- '));
       return;
     }
-
     setSaving(true);
     try {
       const schema = serializeTemplateSchema(nombre.trim(), sections || []);
-      const payload = { nombre: nombre.trim(), descripcion: '', schema };
-      await PlantillasService.savePlantilla(payload);
-      alert('Guardado con éxito');
+      await PlantillasService.savePlantilla({
+        nombre: nombre.trim(),
+        descripcion: '',
+        schema,
+      });
+
+      // limpiar flags/auto-save y volver
+      resetDirty();
+      try {
+        localStorage.removeItem('nodo.form.builder');
+      } catch {}
+      alert('Plantilla guardada');
+      router.replace('/plantillas?created=1');
     } catch (e: any) {
-      console.error('save error', e);
+      console.error(e);
       alert(`Error al guardar: ${e?.message || e}`);
     } finally {
       setSaving(false);
@@ -34,6 +45,10 @@ export default function BuilderHeader() {
 
   return (
     <div className="mb-4 flex items-center gap-3">
+      <button onClick={onBack} className="px-3 py-2 rounded-xl border hover:bg-gray-50">
+        ← Volver
+      </button>
+
       <div className="flex-1">
         <label className="block text-sm mb-1">Nombre de la plantilla *</label>
         <input
@@ -43,6 +58,7 @@ export default function BuilderHeader() {
           placeholder="Ej. Legajo ciudadano"
         />
       </div>
+
       <button
         className="px-4 py-2 rounded-xl bg-sky-600 text-white disabled:opacity-50"
         onClick={onSave}

--- a/frontend/src/components/plantillas/PlantillasPage.tsx
+++ b/frontend/src/components/plantillas/PlantillasPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { PlantillasService } from '@/lib/services/plantillas';
 import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
@@ -12,6 +12,7 @@ const cols = 'grid grid-cols-[1fr_120px_160px_120px_40px] gap-4 items-center';
 
 export default function PlantillasPage() {
   const router = useRouter();
+  const params = useSearchParams();
   const qc = useQueryClient();
   const [q, setQ] = useState('');
   const dq = useDebouncedValue(q, 300);
@@ -20,6 +21,13 @@ export default function PlantillasPage() {
   const [toDelete, setToDelete] = useState<{ id: string; nombre: string } | null>(
     null
   );
+
+  useEffect(() => {
+    if (params.get('created') === '1') {
+      console.log('Plantilla creada con éxito');
+      history.replaceState(null, '', '/plantillas');
+    }
+  }, [params]);
 
   const { data, isLoading, isFetching } = useQuery({
     queryKey: ['plantillas', { dq, estado, page }],


### PR DESCRIPTION
## Summary
- add back button and clean state/redirect after saving in builder
- ensure initial builder section doesn't mark dirty
- normalize plantilla list responses and handle creation toast

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c585bba834832da2ef002546cf7bbd