### PR TITLE
feat: improve dark mode styling

### DIFF
--- a/frontend/src/app/plantillas/crear/page.tsx
+++ b/frontend/src/app/plantillas/crear/page.tsx
@@ -3,7 +3,7 @@ import Builder from '@/components/form/builder/Builder';
 export default function CrearPlantillaPage() {
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl">Crear plantilla</h1>
+      <h1 className="text-2xl text-slate-900 dark:text-slate-100">Crear plantilla</h1>
       <Builder />
     </div>
   );

--- a/frontend/src/components/form/builder/Builder.tsx
+++ b/frontend/src/components/form/builder/Builder.tsx
@@ -54,7 +54,10 @@ export default function Builder({ template }: { template?: any }) {
       <BuilderHeader />
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_16rem] gap-6">
         {/* CANVAS grande */}
-        <div id="canvas" className="min-h-[70vh] border border-dashed rounded-2xl p-4 bg-white/40">
+        <div
+          id="canvas"
+          className="min-h-[70vh] border border-dashed rounded-2xl p-4 bg-white/40 dark:bg-slate-800/40 dark:border-slate-700"
+        >
           <Canvas />
         </div>
 

--- a/frontend/src/components/form/builder/Canvas.tsx
+++ b/frontend/src/components/form/builder/Canvas.tsx
@@ -75,7 +75,7 @@ export default function Canvas() {
             // opcional: abrir modal de componentes automáticamente
             setTimeout(() => window.dispatchEvent(new Event('builder:open-components')), 0);
           }}
-          className="px-3 py-2 rounded-xl border bg-white hover:bg-gray-50"
+          className="px-3 py-2 rounded-xl border bg-white hover:bg-gray-50 dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700"
         >
           + Agregar sección
         </button>
@@ -91,7 +91,7 @@ export default function Canvas() {
 
       <DragOverlay>
         {activeField ? (
-          <div className="min-w-[280px] rounded-xl border bg-white p-3 shadow-lg">
+          <div className="min-w-[280px] rounded-xl border bg-white p-3 shadow-lg dark:bg-slate-800 dark:border-slate-700">
             <FieldCard node={activeField} readonly />
           </div>
         ) : null}

--- a/frontend/src/components/form/builder/ComponentsModal.tsx
+++ b/frontend/src/components/form/builder/ComponentsModal.tsx
@@ -35,7 +35,7 @@ export default function ComponentsModal({ open, onClose }:{open:boolean; onClose
   return (
     <div role="dialog" aria-modal="true" className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/30" onClick={onClose} />
-      <div className="absolute left-1/2 top-20 -translate-x-1/2 w-[min(800px,92vw)] bg-white rounded-2xl shadow-xl p-4">
+      <div className="absolute left-1/2 top-20 -translate-x-1/2 w-[min(800px,92vw)] bg-white rounded-2xl shadow-xl p-4 dark:bg-slate-800 dark:border dark:border-slate-700">
         <h3 className="text-lg font-semibold mb-3">Componentes</h3>
         <div className="space-y-6">
           {Object.entries(GROUPS).map(([title, items])=>(
@@ -45,7 +45,7 @@ export default function ComponentsModal({ open, onClose }:{open:boolean; onClose
                 {items.map(([type, label])=>(
                   <button key={type} type="button"
                     onClick={() => insert(type)}
-                    className="border rounded-xl p-2 text-left hover:bg-gray-50 focus:outline-none focus:ring">
+                    className="border rounded-xl p-2 text-left hover:bg-gray-50 focus:outline-none focus:ring dark:border-slate-700 dark:hover:bg-slate-700">
                     {label}
                   </button>
                 ))}
@@ -54,7 +54,7 @@ export default function ComponentsModal({ open, onClose }:{open:boolean; onClose
           ))}
         </div>
         <div className="text-right mt-4">
-          <button onClick={onClose} className="px-3 py-2 border rounded-xl">Cerrar</button>
+          <button onClick={onClose} className="px-3 py-2 border rounded-xl dark:border-slate-700">Cerrar</button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/form/builder/FieldCard.tsx
+++ b/frontend/src/components/form/builder/FieldCard.tsx
@@ -9,21 +9,21 @@ function MiniPreview({ node }: { node:any }) {
       return (
         <>
           <div className="font-medium">{label}</div>
-          <input className="w-full border rounded p-2" placeholder={node.placeholder || ''} readOnly />
+          <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" placeholder={node.placeholder || ''} readOnly />
         </>
       );
     case 'number':
       return (
         <>
           <div className="font-medium">{label}</div>
-          <input type="number" className="w-full border rounded p-2" readOnly />
+          <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" readOnly />
         </>
       );
     case 'date':
       return (
         <>
           <div className="font-medium">{label}</div>
-          <input type="date" className="w-full border rounded p-2" readOnly />
+          <input type="date" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" readOnly />
         </>
       );
     case 'select':
@@ -32,7 +32,7 @@ function MiniPreview({ node }: { node:any }) {
       return (
         <>
           <div className="font-medium">{label}</div>
-          <select className="w-full border rounded p-2" readOnly>
+          <select className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" readOnly>
             <option>{node.placeholder || 'Seleccione...'}</option>
             {(node.options || []).map((o:any)=> <option key={o.value}>{o.label}</option>)}
           </select>
@@ -44,7 +44,7 @@ function MiniPreview({ node }: { node:any }) {
           <div className="font-medium">{label}</div>
           <div className="flex flex-wrap gap-2">
             {(node.options||[]).slice(0,3).map((o:any)=>(
-              <span key={o.value} className="px-2 py-1 rounded border text-xs">{o.label}</span>
+              <span key={o.value} className="px-2 py-1 rounded border text-xs dark:border-slate-700">{o.label}</span>
             ))}
           </div>
         </>
@@ -53,21 +53,21 @@ function MiniPreview({ node }: { node:any }) {
       return (
         <>
           <div className="font-medium">{label}</div>
-          <input type="file" className="w-full border rounded p-2" readOnly />
+          <input type="file" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" readOnly />
           <p className="text-xs opacity-60">Ext: {(node.accept||[]).join(', ')} • Max {node.maxSizeMB||'—'}MB</p>
         </>
       );
     case 'sum':
-      return (<><div className="font-medium">{label}</div><input className="w-full border rounded p-2 bg-gray-50" value="(auto)" readOnly /></>);
+      return (<><div className="font-medium">{label}</div><input className="w-full border rounded p-2 bg-gray-50 dark:bg-slate-700 dark:border-slate-700" value="(auto)" readOnly /></>);
     case 'phone':
-      return (<><div className="font-medium">{label}</div><input type="tel" className="w-full border rounded p-2" readOnly /></>);
+      return (<><div className="font-medium">{label}</div><input type="tel" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" readOnly /></>);
     case 'cuit_razon_social':
       return (
         <>
           <div className="font-medium">{label}</div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-            <input placeholder="CUIT" className="border rounded p-2" readOnly />
-            <input placeholder="Razón social" className="border rounded p-2" readOnly />
+            <input placeholder="CUIT" className="border rounded p-2 dark:bg-slate-900 dark:border-slate-700" readOnly />
+            <input placeholder="Razón social" className="border rounded p-2 dark:bg-slate-900 dark:border-slate-700" readOnly />
           </div>
         </>
       );
@@ -77,7 +77,7 @@ function MiniPreview({ node }: { node:any }) {
       return (
         <>
           <div className="font-medium">{node.label || 'Grupo'}</div>
-          <div className="rounded border p-2 text-xs opacity-70">Contiene { (node.children||[]).length } subcampos</div>
+          <div className="rounded border p-2 text-xs opacity-70 dark:border-slate-700">Contiene { (node.children||[]).length } subcampos</div>
         </>
       );
     default:
@@ -91,14 +91,14 @@ export default function FieldCard({ node, dragHandle, readonly }:{ node:any; dra
 
   return (
     <div
-      className={`rounded-xl border bg-white p-3 space-y-2 ${readonly ? 'pointer-events-none' : 'cursor-pointer'} ${isSel ? 'ring-2 ring-sky-300' : 'hover:bg-gray-50'}`}
+      className={`rounded-xl border bg-white p-3 space-y-2 dark:bg-slate-800 dark:border-slate-700 ${readonly ? 'pointer-events-none' : 'cursor-pointer'} ${isSel ? 'ring-2 ring-sky-300' : 'hover:bg-gray-50 dark:hover:bg-slate-700'}`}
       onClick={()=> !readonly && setSelected({type:'field', id: node.id})}
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {dragHandle && (
             <button
-              className="px-2 py-1 border rounded text-xs cursor-grab"
+              className="px-2 py-1 border rounded text-xs cursor-grab dark:border-slate-700 dark:text-slate-200"
               {...dragHandle.attributes}
               {...dragHandle.listeners}
               onMouseDownCapture={(e)=>e.stopPropagation()}
@@ -111,9 +111,9 @@ export default function FieldCard({ node, dragHandle, readonly }:{ node:any; dra
         </div>
         {!readonly && (
           <div className="flex gap-2">
-            <button type="button" onClick={(e)=>{e.stopPropagation(); window.dispatchEvent(new CustomEvent('builder:open-props',{detail:{id: node.id}}));}} className="text-xs px-2 py-1 border rounded">Editar</button>
-            <button type="button" onClick={(e)=>{e.stopPropagation(); duplicateNode(node.id);}} className="text-xs px-2 py-1 border rounded">Duplicar</button>
-            <button type="button" onClick={(e)=>{e.stopPropagation(); removeNode(node.id);}} className="text-xs px-2 py-1 border rounded">Eliminar</button>
+            <button type="button" onClick={(e)=>{e.stopPropagation(); window.dispatchEvent(new CustomEvent('builder:open-props',{detail:{id: node.id}}));}} className="text-xs px-2 py-1 border rounded dark:border-slate-700">Editar</button>
+            <button type="button" onClick={(e)=>{e.stopPropagation(); duplicateNode(node.id);}} className="text-xs px-2 py-1 border rounded dark:border-slate-700">Duplicar</button>
+            <button type="button" onClick={(e)=>{e.stopPropagation(); removeNode(node.id);}} className="text-xs px-2 py-1 border rounded dark:border-slate-700">Eliminar</button>
           </div>
         )}
       </div>

--- a/frontend/src/components/form/builder/FieldPropertiesModal.tsx
+++ b/frontend/src/components/form/builder/FieldPropertiesModal.tsx
@@ -46,20 +46,20 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
   return (
     <div role="dialog" aria-modal="true" className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/30" onClick={onClose} />
-      <div className="absolute left-1/2 top-20 -translate-x-1/2 w-[min(820px,92vw)] bg-white rounded-2xl shadow-xl p-5 space-y-4">
+      <div className="absolute left-1/2 top-20 -translate-x-1/2 w-[min(820px,92vw)] bg-white rounded-2xl shadow-xl p-5 space-y-4 dark:bg-slate-800 dark:border dark:border-slate-700">
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold">Propiedades — {String(draft.type).toUpperCase()}</h3>
-          <button className="px-3 py-1 border rounded-lg" onClick={onClose}>✕</button>
+          <button className="px-3 py-1 border rounded-lg dark:border-slate-700" onClick={onClose}>✕</button>
         </div>
 
         <div className="space-y-3 max-h-[65vh] overflow-auto pr-1">
           {/* Comunes */}
           <Row label="Etiqueta">
-            <input className="w-full border rounded p-2" value={draft.label || ''}
+            <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.label || ''}
                    onChange={(e) => setDraft((d: any) => ({ ...d, label: e.target.value }))} />
           </Row>
           <Row label="Key">
-            <input className="w-full border rounded p-2 font-mono" value={draft.key || ''}
+            <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={draft.key || ''}
                    onChange={(e) => setDraft((d: any) => ({ ...d, key: e.target.value }))} />
           </Row>
           <Row label="Obligatorio">
@@ -83,15 +83,15 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
           {(draft.type === 'text' || draft.type === 'textarea') && (
             <>
               <Row label="Placeholder">
-                <input className="w-full border rounded p-2" value={draft.placeholder || ''}
+                <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.placeholder || ''}
                        onChange={(e) => setDraft((d: any) => ({ ...d, placeholder: e.target.value }))} />
               </Row>
               <Row label="Máx. largo">
-                <input type="number" className="w-full border rounded p-2" value={draft.maxLength ?? ''}
+                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.maxLength ?? ''}
                        onChange={(e) => setDraft((d: any) => ({ ...d, maxLength: e.target.value === '' ? undefined : Number(e.target.value) }))} />
               </Row>
               <Row label="Regex">
-                <input className="w-full border rounded p-2 font-mono" value={draft.pattern || ''}
+                <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={draft.pattern || ''}
                        onChange={(e) => setDraft((d: any) => ({ ...d, pattern: e.target.value }))} />
               </Row>
             </>
@@ -100,15 +100,15 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
           {draft.type === 'number' && (
             <>
               <Row label="Mínimo">
-                <input type="number" className="w-full border rounded p-2" value={draft.min ?? ''}
+                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.min ?? ''}
                        onChange={(e) => setDraft((d: any) => ({ ...d, min: e.target.value === '' ? undefined : Number(e.target.value) }))} />
               </Row>
               <Row label="Máximo">
-                <input type="number" className="w-full border rounded p-2" value={draft.max ?? ''}
+                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.max ?? ''}
                        onChange={(e) => setDraft((d: any) => ({ ...d, max: e.target.value === '' ? undefined : Number(e.target.value) }))} />
               </Row>
               <Row label="Step">
-                <input type="number" className="w-full border rounded p-2" value={draft.step ?? ''}
+                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.step ?? ''}
                        onChange={(e) => setDraft((d: any) => ({ ...d, step: e.target.value === '' ? undefined : Number(e.target.value) }))} />
               </Row>
             </>
@@ -151,7 +151,7 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
           {draft.type === 'document' && (
             <>
               <Row label="Extensiones">
-                <input className="w-full border rounded p-2" placeholder=".pdf,.jpg"
+                <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" placeholder=".pdf,.jpg"
                        value={(draft.accept || []).join(',')}
                        onChange={(e) => setDraft((d: any) => ({
                          ...d,
@@ -159,7 +159,7 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
                        }))} />
               </Row>
               <Row label="Tamaño MB">
-                <input type="number" className="w-full border rounded p-2" value={draft.maxSizeMB ?? ''}
+                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.maxSizeMB ?? ''}
                        onChange={(e) => setDraft((d: any) => ({
                          ...d, maxSizeMB: e.target.value === '' ? undefined : Number(e.target.value)
                        }))} />
@@ -170,7 +170,7 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
           {draft.type === 'sum' && (
             <>
               <Row label="Decimales">
-                <input type="number" className="w-full border rounded p-2" value={draft.decimals ?? 0}
+                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.decimals ?? 0}
                        onChange={(e) => setDraft((d: any) => ({ ...d, decimals: Number(e.target.value) || 0 }))} />
               </Row>
               <div>
@@ -202,7 +202,7 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
             <>
               <Row label="Default relativo">
                 <input
-                  className="w-full border rounded p-2"
+                  className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700"
                   placeholder="e.g. +0 days"
                   value={draft.defaultRelative || ''}
                   onChange={(e) => setDraft((d: any) => ({ ...d, defaultRelative: e.target.value }))}
@@ -213,7 +213,7 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
 
           {draft.type === 'info' && (
             <Row label="HTML">
-              <textarea className="w-full border rounded p-2" rows={3} value={draft.html || ''}
+              <textarea className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" rows={3} value={draft.html || ''}
                         onChange={(e) => setDraft((d: any) => ({ ...d, html: e.target.value }))} />
             </Row>
           )}

--- a/frontend/src/components/form/builder/FloatingToolbar.tsx
+++ b/frontend/src/components/form/builder/FloatingToolbar.tsx
@@ -1,10 +1,10 @@
 "use client";
 export default function FloatingToolbar({ onPlus }:{ onPlus:()=>void }) {
   return (
-    <div className="flex flex-col gap-2 p-2 rounded-2xl shadow bg-white/90 border sticky top-28">
+    <div className="flex flex-col gap-2 p-2 rounded-2xl shadow bg-white/90 border sticky top-28 dark:bg-slate-800/90 dark:border-slate-700">
       <button type="button" aria-haspopup="dialog" aria-label="Agregar componente"
         onClick={onPlus}
-        className="w-10 h-10 grid place-items-center rounded-xl bg-sky-100 border">
+        className="w-10 h-10 grid place-items-center rounded-xl bg-sky-100 border dark:bg-sky-800 dark:border-sky-600 dark:text-white">
         +
       </button>
     </div>

--- a/frontend/src/components/form/builder/PropertiesPanel.tsx
+++ b/frontend/src/components/form/builder/PropertiesPanel.tsx
@@ -28,7 +28,7 @@ export default function PropertiesPanel() {
 
   if (!node) return (
     <aside className="mt-4 lg:mt-0 lg:w-80">
-      <div className="rounded-2xl border p-3 bg-white/60">
+      <div className="rounded-2xl border p-3 bg-white/60 dark:bg-slate-800/60 dark:border-slate-700">
         <div className="text-sm opacity-70">Seleccioná un campo para editar sus propiedades.</div>
       </div>
     </aside>
@@ -38,15 +38,15 @@ export default function PropertiesPanel() {
 
   return (
     <aside className="mt-4 lg:mt-0 lg:w-80 space-y-3">
-      <div className="rounded-2xl border p-3 bg-white/60 space-y-2">
+      <div className="rounded-2xl border p-3 bg-white/60 space-y-2 dark:bg-slate-800/60 dark:border-slate-700">
         <h4 className="font-semibold">Propiedades</h4>
 
         <Row label="Etiqueta">
-          <input className="w-full border rounded p-2" value={node.label||''}
+          <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.label||''}
                  onChange={e=>updateNode(node.id, { label: e.target.value })}/>
         </Row>
         <Row label="Key">
-          <input className="w-full border rounded p-2 font-mono" value={node.key||''}
+          <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={node.key||''}
                  onChange={e=>updateNode(node.id, { key: e.target.value })}/>
         </Row>
         <Row label="Obligatorio">
@@ -69,15 +69,15 @@ export default function PropertiesPanel() {
         {(node.type==='text'||node.type==='textarea') && (
           <>
             <Row label="Placeholder">
-              <input className="w-full border rounded p-2" value={node.placeholder||''}
+              <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.placeholder||''}
                      onChange={e=>updateNode(node.id, { placeholder: e.target.value })}/>
             </Row>
             <Row label="Máx. largo">
-              <input type="number" className="w-full border rounded p-2" value={node.maxLength||''}
+              <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.maxLength||''}
                      onChange={e=>updateNode(node.id, { maxLength: Number(e.target.value)||undefined })}/>
             </Row>
             <Row label="Regex">
-              <input className="w-full border rounded p-2 font-mono" value={node.pattern||''}
+              <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={node.pattern||''}
                      onChange={e=>updateNode(node.id, { pattern: e.target.value })}/>
             </Row>
           </>
@@ -86,13 +86,13 @@ export default function PropertiesPanel() {
         {node.type==='number' && (
           <>
             <Row label="Mínimo">
-              <input type="number" className="w-full border rounded p-2" value={node.min ?? ''} onChange={e=>updateNode(node.id, { min: e.target.value===''?undefined:Number(e.target.value) })}/>
+              <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.min ?? ''} onChange={e=>updateNode(node.id, { min: e.target.value===''?undefined:Number(e.target.value) })}/>
             </Row>
             <Row label="Máximo">
-              <input type="number" className="w-full border rounded p-2" value={node.max ?? ''} onChange={e=>updateNode(node.id, { max: e.target.value===''?undefined:Number(e.target.value) })}/>
+              <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.max ?? ''} onChange={e=>updateNode(node.id, { max: e.target.value===''?undefined:Number(e.target.value) })}/>
             </Row>
             <Row label="Step">
-              <input type="number" className="w-full border rounded p-2" value={node.step ?? ''} onChange={e=>updateNode(node.id, { step: e.target.value===''?undefined:Number(e.target.value) })}/>
+              <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.step ?? ''} onChange={e=>updateNode(node.id, { step: e.target.value===''?undefined:Number(e.target.value) })}/>
             </Row>
           </>
         )}
@@ -102,24 +102,24 @@ export default function PropertiesPanel() {
             <div className="text-sm font-medium">Opciones</div>
             {(node.options||[]).map((o:any, i:number)=>(
               <div key={i} className="flex gap-2">
-                <input className="border rounded p-2 flex-1" value={o.label}
+                <input className="border rounded p-2 flex-1 dark:bg-slate-900 dark:border-slate-700" value={o.label}
                        onChange={e=>{
                          const options=[...(node.options||[])]; options[i]={...o,label:e.target.value};
                          updateNode(node.id, { options });
                        }}/>
-                <input className="border rounded p-2 w-40 font-mono" value={o.value}
+                <input className="border rounded p-2 w-40 font-mono dark:bg-slate-900 dark:border-slate-700" value={o.value}
                        onChange={e=>{
                          const options=[...(node.options||[])]; options[i]={...o,value:e.target.value};
                          updateNode(node.id, { options });
                        }}/>
-                <button type="button" className="px-2 border rounded"
+                <button type="button" className="px-2 border rounded dark:border-slate-700"
                         onClick={()=>{
                           const options=[...(node.options||[])]; options.splice(i,1);
                           updateNode(node.id, { options });
                         }}>−</button>
               </div>
             ))}
-            <button type="button" className="px-2 py-1 border rounded"
+            <button type="button" className="px-2 py-1 border rounded dark:border-slate-700"
                     onClick={()=>{
                       const options=[...(node.options||[]), {label:'Opción', value:`op_${(node.options?.length||0)+1}`}];
                       updateNode(node.id, { options });
@@ -130,12 +130,12 @@ export default function PropertiesPanel() {
         {node.type==='document' && (
           <>
             <Row label="Extensiones">
-              <input className="w-full border rounded p-2" placeholder=".pdf,.jpg"
+              <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" placeholder=".pdf,.jpg"
                      value={(node.accept||[]).join(',')}
                      onChange={e=>updateNode(node.id, { accept: e.target.value.split(',').map(s=>s.trim()).filter(Boolean) })}/>
             </Row>
             <Row label="Tamaño MB">
-              <input type="number" className="w-full border rounded p-2" value={node.maxSizeMB ?? ''} onChange={e=>updateNode(node.id, { maxSizeMB: e.target.value===''?undefined:Number(e.target.value) })}/>
+              <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.maxSizeMB ?? ''} onChange={e=>updateNode(node.id, { maxSizeMB: e.target.value===''?undefined:Number(e.target.value) })}/>
             </Row>
           </>
         )}
@@ -143,7 +143,7 @@ export default function PropertiesPanel() {
         {node.type==='sum' && (
           <>
             <Row label="Decimales">
-              <input type="number" className="w-full border rounded p-2" value={node.decimals ?? 0}
+              <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={node.decimals ?? 0}
                      onChange={e=>updateNode(node.id, { decimals: Number(e.target.value)||0 })}/>
             </Row>
             <div>
@@ -153,7 +153,7 @@ export default function PropertiesPanel() {
                   const active = (node.sources||[]).includes(k);
                   return (
                     <button key={k} type="button"
-                      className={`px-2 py-1 border rounded text-xs ${active?'bg-sky-100 border-sky-300':''}`}
+                      className={`px-2 py-1 border rounded text-xs ${active?'bg-sky-100 border-sky-300 dark:bg-sky-900 dark:border-sky-600':''} dark:border-slate-700`}
                       onClick={()=>{
                         const set = new Set(node.sources||[]);
                         if (active) set.delete(k); else set.add(k);
@@ -169,7 +169,7 @@ export default function PropertiesPanel() {
         {node.type==='date' && (
           <>
             <Row label="Default relativo">
-              <input className="w-full border rounded p-2" placeholder='e.g. +0 days'
+              <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" placeholder='e.g. +0 days'
                      onChange={e=>{/* puedes modelar un selector; dejamos libre */}}/>
             </Row>
           </>
@@ -177,8 +177,8 @@ export default function PropertiesPanel() {
 
         {node.type==='info' && (
           <Row label="HTML">
-            <textarea className="w-full border rounded p-2" rows={3} value={node.html||''}
-                      onChange={e=>updateNode(node.id, { html: e.target.value })}/>
+            <textarea className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" rows={3} value={node.html||''}
+                     onChange={e=>updateNode(node.id, { html: e.target.value })}/>
           </Row>
         )}
       </div>

--- a/frontend/src/components/form/builder/dnd/SortableSection.tsx
+++ b/frontend/src/components/form/builder/dnd/SortableSection.tsx
@@ -34,13 +34,13 @@ export default function SortableSection({
     <section
       ref={setNodeRef}
       style={style}
-      className={`rounded-2xl border p-3 bg-white/50 ${isSel ? 'ring-2 ring-sky-300' : ''}`}
+      className={`rounded-2xl border p-3 bg-white/50 dark:bg-slate-800/50 dark:border-slate-700 ${isSel ? 'ring-2 ring-sky-300' : ''}`}
       onClick={() => setSelected({ type: 'section', id })}
     >
-      <header className="flex items-center justify-between rounded-xl px-3 py-2 mb-3">
+      <header className="flex items-center justify-between rounded-xl px-3 py-2 mb-3 bg-slate-100 dark:bg-slate-700">
         <div className="flex items-center gap-2">
           <button
-            className="px-2 py-1 border rounded text-xs cursor-grab"
+            className="px-2 py-1 border rounded text-xs cursor-grab dark:border-slate-700 dark:text-slate-200"
             {...attributes}
             {...listeners}
             onMouseDownCapture={(e) => e.stopPropagation()}
@@ -51,7 +51,7 @@ export default function SortableSection({
           </button>
           {isSel ? (
             <input
-              className="border rounded px-2 py-1"
+              className="border rounded px-2 py-1 dark:bg-slate-900 dark:border-slate-700"
               value={section.title || ''}
               onChange={(e) => updateSection(id, { title: e.target.value })}
             />
@@ -66,7 +66,7 @@ export default function SortableSection({
               e.stopPropagation();
               duplicateSection(id);
             }}
-            className="text-xs px-2 py-1 border rounded"
+            className="text-xs px-2 py-1 border rounded dark:border-slate-700"
           >
             Duplicar
           </button>
@@ -76,7 +76,7 @@ export default function SortableSection({
               e.stopPropagation();
               if (confirm('¿Eliminar sección?')) removeSection(id);
             }}
-            className="text-xs px-2 py-1 border rounded text-red-600"
+            className="text-xs px-2 py-1 border rounded text-red-600 dark:border-slate-700"
           >
             Eliminar
           </button>

--- a/frontend/src/components/plantillas/DeleteConfirm.tsx
+++ b/frontend/src/components/plantillas/DeleteConfirm.tsx
@@ -19,11 +19,11 @@ export default function DeleteConfirm({
   return (
     <div role="dialog" aria-modal="true" className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/30" onClick={onCancel} />
-      <div className="absolute left-1/2 top-24 -translate-x-1/2 w-[min(520px,92vw)] bg-white rounded-2xl shadow-xl p-5">
+      <div className="absolute left-1/2 top-24 -translate-x-1/2 w-[min(520px,92vw)] bg-white rounded-2xl shadow-xl p-5 dark:bg-slate-800 dark:border dark:border-slate-700">
         <h4 className="text-lg font-semibold mb-2">{title}</h4>
         <p className="text-sm opacity-80 mb-4">{message}</p>
         <div className="flex justify-end gap-2">
-          <button onClick={onCancel} className="px-4 py-2 rounded border">
+          <button onClick={onCancel} className="px-4 py-2 rounded border dark:border-slate-700">
             Cancelar
           </button>
           <button

--- a/frontend/src/components/plantillas/PlantillasPage.tsx
+++ b/frontend/src/components/plantillas/PlantillasPage.tsx
@@ -84,7 +84,7 @@ export default function PlantillasPage() {
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Buscar por nombre…"
-            className="w-full border rounded-xl pl-9 pr-3 py-2"
+            className="w-full border rounded-xl pl-9 pr-3 py-2 dark:bg-slate-900 dark:border-slate-700"
           />
           <span className="absolute left-3 top-1/2 -translate-y-1/2 opacity-60">
             🔎
@@ -96,7 +96,7 @@ export default function PlantillasPage() {
             setEstado(e.target.value as Estado);
             setPage(1);
           }}
-          className="border rounded-xl px-3 py-2 w-full md:w-48"
+          className="border rounded-xl px-3 py-2 w-full md:w-48 dark:bg-slate-900 dark:border-slate-700"
         >
           <option value="TODAS">Todas</option>
           <option value="ACTIVO">Activas</option>
@@ -105,8 +105,8 @@ export default function PlantillasPage() {
       </div>
 
       {/* Tabla / Empty / Loader */}
-      <div className="rounded-2xl border bg-white overflow-hidden">
-        <div className={`px-4 py-3 text-xs uppercase tracking-wide bg-gray-50 ${cols}`}>
+      <div className="rounded-2xl border bg-white overflow-hidden dark:bg-slate-800 dark:border-slate-700">
+        <div className={`px-4 py-3 text-xs uppercase tracking-wide bg-gray-50 dark:bg-slate-700 ${cols}`}>
           <div>Nombre</div>
           <div>Versión</div>
           <div>Actualizado</div>
@@ -152,7 +152,7 @@ export default function PlantillasPage() {
           <button
             disabled={page <= 1}
             onClick={() => setPage((p) => Math.max(1, p - 1))}
-            className="px-3 py-1 rounded border disabled:opacity-50"
+            className="px-3 py-1 rounded border disabled:opacity-50 dark:border-slate-700"
           >
             Anterior
           </button>
@@ -162,7 +162,7 @@ export default function PlantillasPage() {
           <button
             disabled={page >= totalPages}
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-            className="px-3 py-1 rounded border disabled:opacity-50"
+            className="px-3 py-1 rounded border disabled:opacity-50 dark:border-slate-700"
           >
             Siguiente
           </button>
@@ -204,28 +204,28 @@ function Row({
   return (
     <div className={`px-4 py-3 ${cols}`}>
       <div className="flex items-center gap-2">
-        <div className="w-8 h-8 grid place-items-center rounded-lg bg-sky-100">
+        <div className="w-8 h-8 grid place-items-center rounded-lg bg-sky-100 dark:bg-sky-900">
           📄
         </div>
         <div>
           <div className="font-medium">{data.nombre}</div>
           <div className="text-xs opacity-60">{data.descripcion || '—'}</div>
           <div className="mt-2 flex gap-2">
-            <button onClick={onEditar} className="text-xs px-2 py-1 rounded border">
+            <button onClick={onEditar} className="text-xs px-2 py-1 rounded border dark:border-slate-700 dark:hover:bg-slate-700">
               Editar
             </button>
-            <button onClick={onPreview} className="text-xs px-2 py-1 rounded border">
+            <button onClick={onPreview} className="text-xs px-2 py-1 rounded border dark:border-slate-700 dark:hover:bg-slate-700">
               Previsualizar
             </button>
-            <button onClick={onUsar} className="text-xs px-2 py-1 rounded border">
+            <button onClick={onUsar} className="text-xs px-2 py-1 rounded border dark:border-slate-700 dark:hover:bg-slate-700">
               Usar
             </button>
-            <button onClick={onDuplicar} className="text-xs px-2 py-1 rounded border">
+            <button onClick={onDuplicar} className="text-xs px-2 py-1 rounded border dark:border-slate-700 dark:hover:bg-slate-700">
               Duplicar
             </button>
             <button
               onClick={onEliminar}
-              className="text-xs px-2 py-1 rounded border text-red-600"
+              className="text-xs px-2 py-1 rounded border text-red-600 dark:border-slate-700 dark:hover:bg-slate-700"
             >
               Eliminar
             </button>


### PR DESCRIPTION
## Summary
- refine dark theme across form builder (canvas, cards, modals, properties)
- adjust template pages and dialog components for dark mode

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c5859e6370832d91807373a22b5c59