### PR TITLE
feat: integrar legajos con plantillas

### DIFF
--- a/frontend/src/app/legajos/[id]/page.tsx
+++ b/frontend/src/app/legajos/[id]/page.tsx
@@ -1,7 +1,7 @@
-import { LegajosService } from '@/lib/LegajosService';
+import { LegajosService } from '@/lib/services/legajos';
 
 export default async function LegajoDetallePage({ params }:{params:{id:string}}) {
-  const legajo: any = await LegajosService.fetchLegajo(params.id);
+  const legajo: any = await LegajosService.get(params.id);
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold">Legajo</h1>

--- a/frontend/src/app/legajos/nuevo/page.tsx
+++ b/frontend/src/app/legajos/nuevo/page.tsx
@@ -1,28 +1,50 @@
 'use client';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { PlantillasService } from '@/lib/services/plantillas';
-import { LegajosService } from '@/lib/LegajosService';
+import { LegajosService } from '@/lib/services/legajos';
 import DynamicForm from '@/components/form/runtime/DynamicForm';
 
 export default function NuevoLegajoPage() {
   const params = useSearchParams();
-  const plantillaId = params.get('plantillaId');
-  const { data } = useQuery<any>({
-    queryKey: ['plantilla', plantillaId],
-    queryFn: () => PlantillasService.fetchPlantilla(plantillaId!),
-    enabled: !!plantillaId,
-  });
   const router = useRouter();
-  if (!plantillaId) return <div>Falta plantillaId</div>;
-  if (!data) return <div>Cargando...</div>;
+  const q = useQueryClient();
+
+  const formId = params.get('formId') || '';
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['plantilla', formId],
+    enabled: !!formId,
+    queryFn: () => PlantillasService.fetchPlantilla(formId),
+  });
+
+  const mut = useMutation({
+    mutationFn: (payload: any) => LegajosService.create(payload),
+    onSuccess: () => {
+      alert('Legajo creado');
+      q.invalidateQueries({ queryKey: ['legajos', 'list'] });
+      router.push('/legajos'); // TODO: página de listado de legajos
+    },
+    onError: (e: any) => alert(e?.message || 'Error al crear el legajo'),
+  });
+
+  if (!formId) return <div className="p-6">Falta <code>formId</code> en la URL.</div>;
+  if (isLoading) return <div className="p-6">Cargando…</div>;
+  if (error || !data) return <div className="p-6">Error cargando la plantilla.</div>;
+
+  // normalizar schema (acepta .schema.nodes o .nodes)
+  const template = data.schema?.id
+    ? data.schema
+    : { id: data.id, name: data.nombre, nodes: data.schema?.nodes ?? data.nodes ?? [] };
+
   return (
-    <DynamicForm
-      schema={data.schema}
-      onSubmit={async (values) => {
-        const res: any = await LegajosService.createLegajo({ plantilla: data.id, data: values });
-        router.push(`/legajos/${res.id}`);
-      }}
-    />
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Nuevo legajo — {data.nombre}</h1>
+      <DynamicForm
+        template={template}
+        onSubmit={(values) =>
+          mut.mutate({ formulario: data.id, data: values }) // TODO: manejar archivos (multipart)
+        }
+      />
+    </div>
   );
 }

--- a/frontend/src/app/legajos/page.tsx
+++ b/frontend/src/app/legajos/page.tsx
@@ -1,0 +1,8 @@
+export default function LegajosPage() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Legajos</h1>
+      <p>Listado de legajos</p>
+    </div>
+  );
+}

--- a/frontend/src/components/form/builder/BuilderHeader.tsx
+++ b/frontend/src/components/form/builder/BuilderHeader.tsx
@@ -1,12 +1,15 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
 import { PlantillasService } from '@/lib/services/plantillas';
 import { serializeTemplateSchema } from '@/lib/serializeTemplate';
+import { PLANTILLAS_QUERY_KEY } from '@/lib/hooks/usePlantillasMin';
 
 export default function BuilderHeader() {
   const router = useRouter();
+  const qc = useQueryClient();
   const { sections, validateAll, nombre, setNombre, resetDirty } = useBuilderStore();
   const [saving, setSaving] = useState(false);
 
@@ -27,6 +30,8 @@ export default function BuilderHeader() {
         descripcion: '',
         schema,
       });
+      await qc.invalidateQueries({ queryKey: PLANTILLAS_QUERY_KEY });
+      await qc.invalidateQueries({ queryKey: ['plantillas', 'list'] });
 
       // limpiar flags/auto-save y volver
       resetDirty();

--- a/frontend/src/components/layout/SideNav.tsx
+++ b/frontend/src/components/layout/SideNav.tsx
@@ -1,9 +1,14 @@
 'use client';
 
 import clsx from 'clsx';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FolderClosed, FolderOpen, FilePlus2, ChevronLeft, ChevronRight } from 'lucide-react';
 import { NAV_ITEMS } from './constants';
 import ActiveLink from './ActiveLink';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { usePlantillasMin } from '@/lib/hooks/usePlantillasMin';
 
 interface SideNavProps {
   open: boolean;
@@ -12,6 +17,8 @@ interface SideNavProps {
 }
 
 export default function SideNav({ open, mini, onToggleMini }: SideNavProps) {
+  const dashboardItem = NAV_ITEMS.find((i) => i.href === '/');
+  const plantillasItem = NAV_ITEMS.find((i) => i.href === '/plantillas');
   return (
     <aside
       className={clsx(
@@ -24,24 +31,37 @@ export default function SideNav({ open, mini, onToggleMini }: SideNavProps) {
     >
       <nav className="flex h-full flex-col p-4 space-y-1">
         <div className="flex-1 space-y-1">
-          {NAV_ITEMS.map((item) => {
-            const Icon = item.icon;
-            return (
-              <ActiveLink
-                key={item.href}
-                href={item.href}
-                className={clsx(mini && 'justify-center')}
-                title={item.label}
-              >
-                <Icon className="h-5 w-5" aria-hidden="true" />
-                {mini ? (
-                  <span className="sr-only">{item.label}</span>
-                ) : (
-                  <span>{item.label}</span>
-                )}
-              </ActiveLink>
-            );
-          })}
+          {dashboardItem && (
+            <ActiveLink
+              href={dashboardItem.href}
+              className={clsx(mini && 'justify-center')}
+              title={dashboardItem.label}
+            >
+              <dashboardItem.icon className="h-5 w-5" aria-hidden="true" />
+              {mini ? (
+                <span className="sr-only">{dashboardItem.label}</span>
+              ) : (
+                <span>{dashboardItem.label}</span>
+              )}
+            </ActiveLink>
+          )}
+
+          <LegajosMenu />
+
+          {plantillasItem && (
+            <ActiveLink
+              href={plantillasItem.href}
+              className={clsx(mini && 'justify-center')}
+              title={plantillasItem.label}
+            >
+              <plantillasItem.icon className="h-5 w-5" aria-hidden="true" />
+              {mini ? (
+                <span className="sr-only">{plantillasItem.label}</span>
+              ) : (
+                <span>{plantillasItem.label}</span>
+              )}
+            </ActiveLink>
+          )}
         </div>
         <button
           onClick={onToggleMini}
@@ -56,5 +76,66 @@ export default function SideNav({ open, mini, onToggleMini }: SideNavProps) {
         </button>
       </nav>
     </aside>
+  );
+}
+
+function LegajosMenu() {
+  const pathname = usePathname();
+  const { data, isLoading } = usePlantillasMin();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (pathname?.startsWith('/legajos')) setOpen(true);
+  }, [pathname]);
+
+  const items = data || [];
+
+  return (
+    <div className="mt-2">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className={`w-full flex items-center gap-2 rounded-lg px-3 py-2 hover:bg-slate-200/60 dark:hover:bg-slate-800/60 ${pathname?.startsWith('/legajos') ? 'bg-slate-200/60 dark:bg-slate-800/60' : ''}`}
+      >
+        {open ? <FolderOpen size={18} /> : <FolderClosed size={18} />}
+        <span className="flex-1 text-left">Legajos</span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.ul
+            key="submenu"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            className="pl-6 overflow-hidden"
+          >
+            <li className="mt-2 mb-1">
+              <Link href="/legajos" className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-200/50">
+                <FilePlus2 size={16} /> <span>Ver legajos</span>
+              </Link>
+            </li>
+
+            {isLoading && (
+              <li className="px-3 py-2 text-sm opacity-70">Cargando…</li>
+            )}
+            {!isLoading && items.length === 0 && (
+              <li className="px-3 py-2 text-sm opacity-60">No hay plantillas</li>
+            )}
+
+            {!isLoading &&
+              items.map((p) => (
+                <li key={p.id}>
+                  <Link
+                    href={`/legajos/nuevo?formId=${p.id}`}
+                    className="block px-3 py-2 rounded hover:bg-slate-200/50"
+                  >
+                    {p.nombre}
+                  </Link>
+                </li>
+              ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/frontend/src/components/layout/constants.ts
+++ b/frontend/src/components/layout/constants.ts
@@ -1,7 +1,6 @@
-import { Home, FolderKanban, FileText } from 'lucide-react';
+import { Home, FileText } from 'lucide-react';
 
 export const NAV_ITEMS = [
   { href: '/', label: 'Dashboard', icon: Home },
-  { href: '/legajos', label: 'Legajos', icon: FolderKanban },
   { href: '/plantillas', label: 'Plantillas', icon: FileText },
 ];

--- a/frontend/src/components/nav/NavSidebar.tsx
+++ b/frontend/src/components/nav/NavSidebar.tsx
@@ -33,14 +33,14 @@ export default function NavSidebar() {
             {plantillas.map((p) => (
               <div key={p.id} className="flex items-center justify-between group">
                 <Link
-                  href={`/legajos?plantillaId=${p.id}`}
+                  href={`/legajos?formId=${p.id}`}
                   className={`px-2 py-1 rounded hover:bg-gray-100 text-sm ${pathname?.startsWith('/legajos') ? 'font-medium' : ''}`}
                 >
                   {p.nombre}
                 </Link>
                 <button
                   title="Crear legajo"
-                  onClick={() => router.push(`/legajos/nuevo?plantillaId=${p.id}`)}
+                  onClick={() => router.push(`/legajos/nuevo?formId=${p.id}`)}
                   className="opacity-60 group-hover:opacity-100 text-sm px-2"
                 >＋</button>
               </div>

--- a/frontend/src/components/plantillas/PlantillasPage.tsx
+++ b/frontend/src/components/plantillas/PlantillasPage.tsx
@@ -30,7 +30,7 @@ export default function PlantillasPage() {
   }, [params]);
 
   const { data, isLoading, isFetching } = useQuery({
-    queryKey: ['plantillas', { dq, estado, page }],
+    queryKey: ['plantillas', 'list', { dq, estado, page }],
     queryFn: () =>
       PlantillasService.fetchPlantillas({
         search: dq || undefined,
@@ -44,7 +44,7 @@ export default function PlantillasPage() {
   const del = useMutation({
     mutationFn: (id: string) => PlantillasService.deletePlantilla(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['plantillas'] });
+      qc.invalidateQueries({ queryKey: ['plantillas', 'list'] });
       setToDelete(null);
     },
   });
@@ -58,7 +58,7 @@ export default function PlantillasPage() {
         schema: tpl.schema,
       });
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['plantillas'] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['plantillas', 'list'] }),
   });
 
   const results = data?.results ?? [];
@@ -142,7 +142,7 @@ export default function PlantillasPage() {
                   } catch {}
                   window.open('/plantillas/previsualizacion', '_blank');
                 }}
-                onUsar={() => router.push(`/legajos/nuevo?plantillaId=${p.id}`)}
+                onUsar={() => router.push(`/legajos/nuevo?formId=${p.id}`)}
                 onDuplicar={() => duplicar.mutate(p)}
                 onEliminar={() => setToDelete({ id: p.id, nombre: p.nombre })}
               />

--- a/frontend/src/lib/LegajosService.ts
+++ b/frontend/src/lib/LegajosService.ts
@@ -1,6 +1,0 @@
-import { api } from './api';
-
-export const LegajosService = {
-  createLegajo: (data:any) => api.post('/legajos/', data),
-  fetchLegajo: (id:string) => api.get(`/legajos/${id}/`),
-};

--- a/frontend/src/lib/hooks/usePlantillasMin.ts
+++ b/frontend/src/lib/hooks/usePlantillasMin.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { PlantillasService } from '@/lib/services/plantillas';
+
+export const PLANTILLAS_QUERY_KEY = ['plantillas','list','min'] as const;
+
+export function usePlantillasMin() {
+  return useQuery({
+    queryKey: PLANTILLAS_QUERY_KEY,
+    queryFn: async () => {
+      const res = await PlantillasService.fetchPlantillas({ page: 1, page_size: 100 });
+      // Mapea a lo mínimo necesario para el menú
+      return (res.results || []).map((p: any) => ({
+        id: p.id,
+        nombre: p.nombre,
+        version: p.version,
+        estado: p.estado,
+      }));
+    },
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/lib/services/legajos.ts
+++ b/frontend/src/lib/services/legajos.ts
@@ -1,0 +1,17 @@
+import { http } from './http';
+
+export const LegajosService = {
+  create: (payload: { formulario: string; data: any }) =>
+    http('/legajos/', { method: 'POST', body: JSON.stringify(payload) }),
+  // (Opcional) listar y detalle:
+  list: (
+    params: { formId?: string; page?: number; page_size?: number } = {}
+  ) => {
+    const q = new URLSearchParams();
+    if (params.formId) q.set('formulario', params.formId);
+    if (params.page) q.set('page', String(params.page));
+    if (params.page_size) q.set('page_size', String(params.page_size));
+    return http(`/legajos/${q.toString() ? `?${q}` : ''}`);
+  },
+  get: (id: string) => http(`/legajos/${id}/`),
+};


### PR DESCRIPTION
## Summary
- agregar servicio de legajos
- menú lateral de legajos con plantillas dinámicas
- crear legajo desde plantilla con invalidación de queries

## Testing
- `npm install vitest@^1.5.0 @testing-library/react@^15.0.1 @testing-library/jest-dom@^6.4.2 jsdom@^24.0.0 --no-save --package-lock=false` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5886823dc832d860ce93ce57ac0d5