### PR TITLE
feat(frontend): add framer motion dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,8 @@
     "react-grid-layout": "^1.3.4",
     "react-hook-form": "^7.62.0",
     "zod": "^3.25.8",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.13",


### PR DESCRIPTION
## Summary
- add framer-motion dependency to frontend

## Testing
- `npm i -E framer-motion@11` *(fails: 403 Forbidden)*
- `npm run build` *(fails: Module not found: Can't resolve 'framer-motion')*

------
https://chatgpt.com/codex/tasks/task_e_68c592b85494832d8898b54941a563c9