### PR TITLE
Fix SideNav icons and update lucide dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "react-hook-form": "^7.62.0",
     "zod": "^3.25.8",
     "zustand": "^4.5.2",
-    "lucide-react": "^0.458.0"
+    "lucide-react": "^0.460.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.13",

--- a/frontend/src/components/layout/ActiveLink.tsx
+++ b/frontend/src/components/layout/ActiveLink.tsx
@@ -29,7 +29,6 @@ export default function ActiveLink({ href, children, className, title }: ActiveL
     <Link
       href={href}
       onClick={handleClick}
-      onClick={handleClick}
       aria-current={isActive ? 'page' : undefined}
       className={clsx(
         'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',

--- a/frontend/src/components/layout/SideNav.tsx
+++ b/frontend/src/components/layout/SideNav.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState, useEffect } from 'react';
-import { FolderClosed, FolderOpen, FilePlus, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Folder, FolderOpen, FilePlus2, ChevronLeft, ChevronRight } from 'lucide-react';
 import { NAV_ITEMS } from './constants';
 import ActiveLink from './ActiveLink';
 import { usePlantillasMin } from '@/lib/hooks/usePlantillasMin';
@@ -15,9 +15,16 @@ interface SideNavProps {
   onToggleMini: () => void;
 }
 
+// Helper para evitar crashear si algún icono viniera undefined
+function SafeIcon(Comp: any, props: any) {
+  // Si Comp no es una función/componente válido, muestro fallback
+  return typeof Comp === 'function' ? <Comp {...props} /> : <span aria-hidden>■</span>;
+}
+
 export default function SideNav({ open, mini, onToggleMini }: SideNavProps) {
   const dashboardItem = NAV_ITEMS.find((i) => i.href === '/');
   const plantillasItem = NAV_ITEMS.find((i) => i.href === '/plantillas');
+
   return (
     <aside
       className={clsx(
@@ -36,8 +43,13 @@ export default function SideNav({ open, mini, onToggleMini }: SideNavProps) {
               className={clsx(mini && 'justify-center')}
               title={dashboardItem.label}
             >
-              <dashboardItem.icon className="h-5 w-5" aria-hidden />
-              {mini ? <span className="sr-only">{dashboardItem.label}</span> : <span>{dashboardItem.label}</span>}
+              {/* icono seguro */}
+              {SafeIcon(dashboardItem.icon, { className: 'h-5 w-5', 'aria-hidden': true })}
+              {mini ? (
+                <span className="sr-only">{dashboardItem.label}</span>
+              ) : (
+                <span>{dashboardItem.label}</span>
+              )}
             </ActiveLink>
           )}
 
@@ -49,8 +61,12 @@ export default function SideNav({ open, mini, onToggleMini }: SideNavProps) {
               className={clsx(mini && 'justify-center')}
               title={plantillasItem.label}
             >
-              <plantillasItem.icon className="h-5 w-5" aria-hidden />
-              {mini ? <span className="sr-only">{plantillasItem.label}</span> : <span>{plantillasItem.label}</span>}
+              {SafeIcon(plantillasItem.icon, { className: 'h-5 w-5', 'aria-hidden': true })}
+              {mini ? (
+                <span className="sr-only">{plantillasItem.label}</span>
+              ) : (
+                <span>{plantillasItem.label}</span>
+              )}
             </ActiveLink>
           )}
         </div>
@@ -88,11 +104,12 @@ function LegajosMenu() {
           pathname?.startsWith('/legajos') && 'bg-slate-200/60 dark:bg-slate-800/60'
         )}
       >
-        {open ? <FolderOpen size={18} /> : <FolderClosed size={18} />}
+        {/* Usar Folder (cerrado) y FolderOpen (abierto) en lugar de FolderClosed */}
+        {open ? <FolderOpen size={18} /> : <Folder size={18} />}
         <span className="flex-1 text-left">Legajos</span>
       </button>
 
-      {/* Animación sin framer-motion */}
+      {/* Despliegue con CSS (sin framer-motion) */}
       <div
         className={clsx(
           'pl-6 overflow-hidden transition-[grid-template-rows,opacity] duration-200 grid',
@@ -102,7 +119,7 @@ function LegajosMenu() {
         <ul className="min-h-0 overflow-hidden">
           <li className="mt-2 mb-1">
             <Link href="/legajos" className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-200/50">
-              <FilePlus size={16} /> <span>Ver legajos</span>
+              <FilePlus2 size={16} /> <span>Ver legajos</span>
             </Link>
           </li>
 

--- a/frontend/src/lib/hooks/usePlantillasMin.ts
+++ b/frontend/src/lib/hooks/usePlantillasMin.ts
@@ -7,14 +7,19 @@ export function usePlantillasMin() {
   return useQuery({
     queryKey: PLANTILLAS_QUERY_KEY,
     queryFn: async () => {
-      const res = await PlantillasService.fetchPlantillas({ page: 1, page_size: 100 });
-      // Mapea a lo mínimo necesario para el menú
-      return (res.results || []).map((p: any) => ({
-        id: p.id,
-        nombre: p.nombre,
-        version: p.version,
-        estado: p.estado,
-      }));
+      try {
+        const res = await PlantillasService.fetchPlantillas({ page: 1, page_size: 100 });
+        // Mapea a lo mínimo necesario para el menú
+        return (res.results || []).map((p: any) => ({
+          id: p.id,
+          nombre: p.nombre,
+          version: p.version,
+          estado: p.estado,
+        }));
+      } catch (err) {
+        console.error(err);
+        return [];
+      }
     },
     staleTime: 60_000,
   });


### PR DESCRIPTION
## Summary
- update lucide-react dependency version
- use supported lucide icons in SideNav and add SafeIcon helper
- ensure ActiveLink only registers one click handler and keep unsaved changes guard
- wrap usePlantillasMin fetch in try/catch

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lucide-react)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aa06d340832d970923a177c39cbc