### PR TITLE
fix: show folder icon in Legajos menu

### DIFF
--- a/frontend/src/components/layout/SideNav.tsx
+++ b/frontend/src/components/layout/SideNav.tsx
@@ -17,7 +17,7 @@ interface SideNavProps {
 
 // Helper: si un icono viniera undefined, renderiza fallback y evita el crash
 function SafeIcon(Comp: any, props: any) {
-  if (typeof Comp === 'function') return <Comp {...props} />;
+  if (Comp) return <Comp {...props} />;
   if (process.env.NODE_ENV !== 'production') {
     // ayuda para debuggear qué ícono faltó
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- render icon components even when `lucide-react` exports them as objects so the Legajos menu shows the folder icon again

## Testing
- `npm test` *(fails: vitest not found)*
- `npx --yes vitest@latest run` *(fails: 403 Forbidden)*
- `npm install --no-save --no-package-lock vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e64acf88832d82244f17d379bb28