### PR TITLE
fix: ensure Legajos menu renders folder icon

### DIFF
--- a/frontend/src/components/layout/SideNav.tsx
+++ b/frontend/src/components/layout/SideNav.tsx
@@ -3,8 +3,14 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState, useEffect } from 'react';
-import * as Icons from 'lucide-react';
+import { useState, useEffect, type SVGProps } from 'react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  Folder,
+  FolderOpen,
+} from 'lucide-react';
 import { NAV_ITEMS } from './constants';
 import ActiveLink from './ActiveLink';
 import { usePlantillasMin } from '@/lib/hooks/usePlantillasMin';
@@ -69,12 +75,64 @@ export default function SideNav({ open, mini, onToggleMini }: SideNavProps) {
           className="mt-2 flex items-center justify-center rounded-md p-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
           aria-label="Compactar menú"
         >
-          {mini ? <Icons.ChevronRight className="h-5 w-5" /> : <Icons.ChevronLeft className="h-5 w-5" />}
+          {mini ? (
+            <ChevronRight className="h-5 w-5" />
+          ) : (
+            <ChevronLeft className="h-5 w-5" />
+          )}
         </button>
       </nav>
     </aside>
   );
 }
+
+// ===== Fallbacks seguros para íconos de carpeta =====
+interface IconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+}
+
+function InlineFolder({ size = 24, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}
+
+function InlineFolderOpen({ size = 24, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M3 3h6l2 3h10a2 2 0 0 1 2 2v4" />
+      <path d="M3 7v10a2 2 0 0 0 2 2h14" />
+      <path d="M3 7h18l-2 8H5l-2-8Z" />
+    </svg>
+  );
+}
+
+const FolderClosedIcon = (Folder as any) ?? ((p: any) => <InlineFolder {...p} />);
+const FolderOpenIcon = (FolderOpen as any) ?? ((p: any) => <InlineFolderOpen {...p} />);
 
 function LegajosMenu() {
   const pathname = usePathname();
@@ -97,7 +155,11 @@ function LegajosMenu() {
           pathname?.startsWith('/legajos') && 'bg-slate-200/60 dark:bg-slate-800/60'
         )}
       >
-        {open ? <Icons.FolderOpen size={18} /> : <Icons.Folder size={18} />}
+        {open ? (
+          <FolderOpenIcon className="h-5 w-5" />
+        ) : (
+          <FolderClosedIcon className="h-5 w-5" />
+        )}
         <span className="flex-1 text-left">Legajos</span>
       </button>
 
@@ -110,7 +172,7 @@ function LegajosMenu() {
         <ul className="min-h-0 overflow-hidden">
           <li className="mt-2 mb-1">
             <Link href="/legajos" className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-200/50">
-              <Icons.FileText size={16} /> <span>Ver legajos</span>
+              <FileText size={16} /> <span>Ver legajos</span>
             </Link>
           </li>
 


### PR DESCRIPTION
## Summary
- add inline SVG fallbacks for Folder and FolderOpen icons
- swap Legajos menu to use safe folder icon components
- align folder icon size with other sidebar icons

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c76aca0a98832d97897a1e39050bf8