### PR TITLE
feat: add visual legajo configuration

### DIFF
--- a/backend/legajos/services.py
+++ b/backend/legajos/services.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+from typing import Any, Dict
+
+from .models import Legajo
+
+
+class LegajoMetaService:
+    @staticmethod
+    def compute(legajo: Legajo) -> Dict[str, Any]:
+        data = legajo.data or {}
+
+        def count_fields(nodes, values):
+            total = 0
+            filled = 0
+            for n in nodes or []:
+                t = n.get("type")
+                if t == "section":
+                    t_tot, t_fill = count_fields(n.get("children", []), values)
+                    total += t_tot
+                    filled += t_fill
+                elif t == "group":
+                    # ignore groups for simplicity
+                    for c in n.get("children", []):
+                        total += 1
+                        if values.get(c.get("key")) not in (None, "", [], {}):
+                            filled += 1
+                else:
+                    total += 1
+                    if values.get(n.get("key")) not in (None, "", [], {}):
+                        filled += 1
+            return total, filled
+
+        total, filled = count_fields(legajo.plantilla.schema.get("nodes", []), data)
+        completitud = int((filled / total) * 100) if total else 0
+
+        counts = {
+            "intervenciones": len(data.get("intervenciones", [])),
+            "archivos": len(data.get("archivos", [])),
+            "alertas_activas": len([a for a in data.get("alertas", []) if a.get("activa")]),
+        }
+        metrics = {
+            "dias_sin_contacto": data.get("dias_sin_contacto", 0),
+        }
+        trends = {
+            "intervenciones": data.get("trend_intervenciones", ""),
+        }
+        return {
+            "completitud": completitud,
+            "counts": counts,
+            "metrics": metrics,
+            "trends": trends,
+        }

--- a/backend/legajos/tests/test_get_legajo.py
+++ b/backend/legajos/tests/test_get_legajo.py
@@ -1,0 +1,27 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from plantillas.models import Plantilla
+from legajos.models import Legajo
+from legajos.viewsets import LegajoViewSet
+
+
+def test_get_legajo_includes_visual_and_meta(db):
+    plantilla = Plantilla.objects.create(
+        nombre="P",
+        schema={},
+        visual_config={"header": {"title": "t"}},
+    )
+    legajo = Legajo.objects.create(plantilla=plantilla, data={})
+
+    factory = APIRequestFactory()
+    request = factory.get(f"/legajos/{legajo.id}/")
+    User = get_user_model()
+    user = User.objects.create_user(username="u", password="p")
+    force_authenticate(request, user=user)
+
+    view = LegajoViewSet.as_view({"get": "retrieve"})
+    response = view(request, pk=str(legajo.id))
+    assert response.status_code == 200
+    assert response.data["visual_config"] == plantilla.visual_config
+    assert "meta" in response.data

--- a/backend/legajos/tests/test_meta_service.py
+++ b/backend/legajos/tests/test_meta_service.py
@@ -1,0 +1,22 @@
+from plantillas.models import Plantilla
+from legajos.models import Legajo
+from legajos.services import LegajoMetaService
+
+
+def test_meta_service(db):
+    schema = {"nodes": [{"type": "text", "key": "a"}, {"type": "text", "key": "b"}]}
+    plantilla = Plantilla.objects.create(nombre="P", schema=schema)
+    legajo = Legajo.objects.create(
+        plantilla=plantilla,
+        data={
+            "a": "1",
+            "intervenciones": [1, 2],
+            "archivos": [1],
+            "alertas": [{"activa": True}, {"activa": False}],
+            "dias_sin_contacto": 5,
+        },
+    )
+    meta = LegajoMetaService.compute(legajo)
+    assert meta["completitud"] == 50
+    assert meta["counts"] == {"intervenciones": 2, "archivos": 1, "alertas_activas": 1}
+    assert meta["metrics"]["dias_sin_contacto"] == 5

--- a/backend/legajos/viewsets.py
+++ b/backend/legajos/viewsets.py
@@ -1,7 +1,8 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, response
 from rest_framework.permissions import IsAuthenticated
 from .models import Legajo
 from .serializers import LegajoSerializer
+from .services import LegajoMetaService
 
 
 class LegajoViewSet(viewsets.ModelViewSet):
@@ -9,3 +10,15 @@ class LegajoViewSet(viewsets.ModelViewSet):
     serializer_class = LegajoSerializer
     permission_classes = [IsAuthenticated]
     http_method_names = ["get", "post"]
+
+    def retrieve(self, request, *args, **kwargs):
+        inst = self.get_object()
+        meta = LegajoMetaService.compute(inst)
+        return response.Response(
+            {
+                "data": inst.data,
+                "plantilla": str(inst.plantilla_id),
+                "visual_config": inst.plantilla.visual_config or {},
+                "meta": meta,
+            }
+        )

--- a/backend/plantillas/migrations/0002_plantilla_visual_config.py
+++ b/backend/plantillas/migrations/0002_plantilla_visual_config.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("plantillas", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="plantilla",
+            name="visual_config",
+            field=models.JSONField(default=dict, blank=True),
+        ),
+    ]

--- a/backend/plantillas/models.py
+++ b/backend/plantillas/models.py
@@ -13,6 +13,7 @@ class Plantilla(models.Model):
     nombre = models.CharField(max_length=255, unique=False)
     descripcion = models.TextField(null=True, blank=True)
     schema = models.JSONField()
+    visual_config = models.JSONField(default=dict, blank=True)
     version = models.PositiveIntegerField(default=1)
     estado = models.CharField(max_length=10, choices=Estado.choices, default=Estado.ACTIVO)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/plantillas/serializers.py
+++ b/backend/plantillas/serializers.py
@@ -11,12 +11,13 @@ class PlantillaSerializer(serializers.ModelSerializer):
             "nombre",
             "descripcion",
             "schema",
+            "visual_config",
             "version",
             "estado",
             "created_at",
             "updated_at",
         )
-        read_only_fields = ("version", "estado", "created_at", "updated_at")
+        read_only_fields = ("version", "estado", "visual_config", "created_at", "updated_at")
 
     def validate_nombre(self, value):
         qs = Plantilla.objects.filter(nombre__iexact=value)
@@ -39,3 +40,7 @@ class PlantillaSerializer(serializers.ModelSerializer):
             setattr(instance, attr, val)
         instance.save()
         return instance
+
+
+class PlantillaVisualConfigSerializer(serializers.Serializer):
+    visual_config = serializers.JSONField(default=dict)

--- a/backend/plantillas/tests/test_visual_config_serializer.py
+++ b/backend/plantillas/tests/test_visual_config_serializer.py
@@ -1,0 +1,11 @@
+from plantillas.serializers import PlantillaVisualConfigSerializer
+
+
+def test_visual_config_serializer_valid():
+    s = PlantillaVisualConfigSerializer(data={"visual_config": {"render_mode": "visual"}})
+    assert s.is_valid(), s.errors
+
+
+def test_visual_config_serializer_invalid():
+    s = PlantillaVisualConfigSerializer(data={"visual_config": "no"})
+    assert not s.is_valid()

--- a/backend/plantillas/viewsets.py
+++ b/backend/plantillas/viewsets.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets, decorators, response, status, filters
 from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import DjangoFilterBackend
 from .models import Plantilla
-from .serializers import PlantillaSerializer
+from .serializers import PlantillaSerializer, PlantillaVisualConfigSerializer
 
 
 class PlantillaViewSet(viewsets.ModelViewSet):
@@ -27,3 +27,12 @@ class PlantillaViewSet(viewsets.ModelViewSet):
         if exclude:
             qs = qs.exclude(pk=exclude)
         return response.Response({"exists": qs.exists()})
+
+    @decorators.action(detail=True, methods=["patch"], url_path="visual-config")
+    def visual_config(self, request, pk=None):
+        plantilla = self.get_object()
+        serializer = PlantillaVisualConfigSerializer(data={"visual_config": request.data or {}})
+        serializer.is_valid(raise_exception=True)
+        plantilla.visual_config = serializer.validated_data["visual_config"]
+        plantilla.save(update_fields=["visual_config"])
+        return response.Response(serializer.validated_data["visual_config"])

--- a/frontend/src/app/legajos/[id]/page.tsx
+++ b/frontend/src/app/legajos/[id]/page.tsx
@@ -1,18 +1,38 @@
 import { LegajosService } from '@/lib/services/legajos';
+import { enableVisualLegajo } from '@/lib/config';
+import LegajoHeader from '@/components/legajo/LegajoHeader';
+import CounterGrid from '@/components/legajo/CounterGrid';
 
 export default async function LegajoDetallePage({ params }:{params:{id:string}}) {
   const legajo: any = await LegajosService.get(params.id);
-  return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">Legajo</h1>
-      <div className="space-y-1 text-sm">
-        <div><strong>Plantilla:</strong> {legajo.plantilla}</div>
-        <div><strong>Creado:</strong> {new Date(legajo.created_at).toLocaleString()}</div>
-        <div><strong>Actualizado:</strong> {new Date(legajo.updated_at).toLocaleString()}</div>
+  const hasVisual =
+    enableVisualLegajo && legajo.visual_config && Object.keys(legajo.visual_config).length > 0;
+
+  if (!hasVisual) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold">Legajo</h1>
+        <div className="space-y-1 text-sm">
+          <div>
+            <strong>Plantilla:</strong> {legajo.plantilla}
+          </div>
+        </div>
+        <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto">
+          {JSON.stringify(legajo.data, null, 2)}
+        </pre>
       </div>
-      <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto">
-        {JSON.stringify(legajo.data, null, 2)}
-      </pre>
+    );
+  }
+
+  const cfg = legajo.visual_config;
+  return (
+    <div className="space-y-6">
+      {cfg.header && (
+        <LegajoHeader cfg={cfg.header} data={legajo.data} meta={legajo.meta} />
+      )}
+      {cfg.counters && (
+        <CounterGrid cfg={cfg.counters} data={legajo.data} meta={legajo.meta} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/form/builder/Builder.tsx
+++ b/frontend/src/components/form/builder/Builder.tsx
@@ -1,21 +1,29 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
+import { useVisualConfigStore } from '@/lib/store/usePlantillaVisualStore';
+import { enableVisualLegajo } from '@/lib/config';
 import Canvas from './Canvas';
 import FloatingToolbar from './FloatingToolbar';
 import ComponentsModal from './ComponentsModal';
 import BuilderHeader from './BuilderHeader';
 import FieldPropertiesModal from './FieldPropertiesModal';
+import VisualEditor from '../visual/VisualEditor';
 
 export default function Builder({ template }: { template?: any }) {
   const { setTemplate, dirty, sections, addSection } = useBuilderStore();
+  const { setVisualConfig } = useVisualConfigStore();
 
   const [openComponents, setOpenComponents] = useState(false);
   const [propsId, setPropsId] = useState<string | null>(null);
+  const [tab, setTab] = useState<'campos' | 'visual'>('campos');
 
   useEffect(() => {
-    if (template) setTemplate(template);
-  }, [template, setTemplate]);
+    if (template) {
+      setTemplate(template);
+      setVisualConfig(template.visual_config || {});
+    }
+  }, [template, setTemplate, setVisualConfig]);
 
   useEffect(() => {
     if (!sections?.length) {
@@ -52,24 +60,44 @@ export default function Builder({ template }: { template?: any }) {
   return (
     <>
       <BuilderHeader />
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_16rem] gap-6">
-        {/* CANVAS grande */}
-        <div
-          id="canvas"
-          className="min-h-[70vh] border border-dashed rounded-2xl p-4 bg-white/40 dark:bg-slate-800/40 dark:border-slate-700"
-        >
-          <Canvas />
+      {enableVisualLegajo && (
+        <div className="mb-4 flex gap-2">
+          <button
+            className={`px-3 py-1 rounded ${tab === 'campos' ? 'bg-sky-600 text-white' : 'bg-gray-100'}`}
+            onClick={() => setTab('campos')}
+          >
+            Campos
+          </button>
+          <button
+            className={`px-3 py-1 rounded ${tab === 'visual' ? 'bg-sky-600 text-white' : 'bg-gray-100'}`}
+            onClick={() => setTab('visual')}
+          >
+            Visual
+          </button>
         </div>
+      )}
+      {tab === 'visual' && enableVisualLegajo ? (
+        <VisualEditor />
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_16rem] gap-6">
+          {/* CANVAS grande */}
+          <div
+            id="canvas"
+            className="min-h-[70vh] border border-dashed rounded-2xl p-4 bg-white/40 dark:bg-slate-800/40 dark:border-slate-700"
+          >
+            <Canvas />
+          </div>
 
-        {/* MENÚ chico (toolbar con “+” → modal de componentes) */}
-        <div className="sticky top-24 h-fit">
-          <FloatingToolbar onPlus={() => setOpenComponents(true)} />
+          {/* MENÚ chico (toolbar con “+” → modal de componentes) */}
+          <div className="sticky top-24 h-fit">
+            <FloatingToolbar onPlus={() => setOpenComponents(true)} />
+          </div>
+
+          {/* Popups */}
+          <ComponentsModal open={openComponents} onClose={() => setOpenComponents(false)} />
+          <FieldPropertiesModal open={!!propsId} fieldId={propsId} onClose={() => setPropsId(null)} />
         </div>
-
-        {/* Popups */}
-        <ComponentsModal open={openComponents} onClose={() => setOpenComponents(false)} />
-        <FieldPropertiesModal open={!!propsId} fieldId={propsId} onClose={() => setPropsId(null)} />
-      </div>
+      )}
     </>
   );
 }

--- a/frontend/src/components/form/visual/EditorCounters.tsx
+++ b/frontend/src/components/form/visual/EditorCounters.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useVisualConfigStore } from '@/lib/store/usePlantillaVisualStore';
+
+export default function EditorCounters() {
+  const { visualConfig, setVisualConfig } = useVisualConfigStore();
+  const items = visualConfig.counters?.items || [];
+
+  const updateItem = (idx: number, patch: any) => {
+    const next = [...items];
+    next[idx] = { ...next[idx], ...patch };
+    setVisualConfig({
+      ...visualConfig,
+      counters: { ...(visualConfig.counters || {}), items: next },
+    });
+  };
+
+  const add = () => {
+    setVisualConfig({
+      ...visualConfig,
+      counters: {
+        ...(visualConfig.counters || {}),
+        items: [...items, { id: `c${items.length}`, label: '' }],
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <h3 className="font-medium">Contadores</h3>
+      {items.map((it: any, idx: number) => (
+        <div key={idx} className="flex gap-2">
+          <input
+            className="border rounded px-2 py-1 w-full"
+            placeholder="Etiqueta"
+            value={it.label || ''}
+            onChange={(e) => updateItem(idx, { label: e.target.value })}
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        className="px-2 py-1 border rounded"
+      >
+        Agregar
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/form/visual/EditorHeader.tsx
+++ b/frontend/src/components/form/visual/EditorHeader.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useVisualConfigStore } from '@/lib/store/usePlantillaVisualStore';
+
+export default function EditorHeader() {
+  const { visualConfig, setVisualConfig } = useVisualConfigStore();
+  const cfg = visualConfig.header || {};
+  return (
+    <div className="space-y-2">
+      <h3 className="font-medium">Encabezado</h3>
+      <div>
+        <label className="block text-sm">Título</label>
+        <input
+          className="border rounded px-2 py-1 w-full"
+          value={cfg.title || ''}
+          onChange={(e) =>
+            setVisualConfig({ ...visualConfig, header: { ...cfg, title: e.target.value } })
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/form/visual/VisualEditor.tsx
+++ b/frontend/src/components/form/visual/VisualEditor.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useState } from 'react';
+import EditorHeader from './EditorHeader';
+import EditorCounters from './EditorCounters';
+import { useVisualConfigStore } from '@/lib/store/usePlantillaVisualStore';
+import { PlantillasService } from '@/lib/services/plantillas';
+import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
+
+export default function VisualEditor() {
+  const { visualConfig } = useVisualConfigStore();
+  const plantillaId = useBuilderStore((s) => s.plantillaId);
+  const [saving, setSaving] = useState(false);
+
+  const onSave = async () => {
+    if (!plantillaId) return;
+    setSaving(true);
+    try {
+      await PlantillasService.updateVisualConfig(plantillaId, visualConfig);
+      alert('Config visual guardada');
+    } catch (e: any) {
+      alert(e?.message || e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <EditorHeader />
+      <EditorCounters />
+      <button
+        className="px-4 py-2 rounded bg-sky-600 text-white disabled:opacity-50"
+        onClick={onSave}
+        disabled={saving}
+      >
+        {saving ? 'Guardando…' : 'Guardar'}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/legajo/CounterGrid.tsx
+++ b/frontend/src/components/legajo/CounterGrid.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { renderTpl } from '@/lib/tpl';
+
+interface Props {
+  cfg: any;
+  data: any;
+  meta: any;
+}
+
+export default function CounterGrid({ cfg, data, meta }: Props) {
+  const cols =
+    cfg.layout === 'grid-4'
+      ? 'grid-cols-4'
+      : cfg.layout === 'grid-3'
+      ? 'grid-cols-3'
+      : 'grid-cols-2';
+  const ctx = { data, meta, ...meta };
+  return (
+    <div className={`grid ${cols} gap-4`}>
+      {(cfg.items || []).map((it: any) => (
+        <div key={it.id} className="p-4 bg-white rounded shadow">
+          <div className="text-sm text-gray-500">{it.label}</div>
+          <div className="text-xl font-semibold">
+            {renderTpl(it.value, ctx)}
+          </div>
+          {it.trend && (
+            <div className="text-xs text-gray-400">{renderTpl(it.trend, ctx)}</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/legajo/LegajoHeader.tsx
+++ b/frontend/src/components/legajo/LegajoHeader.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { renderTpl } from '@/lib/tpl';
+
+interface Props {
+  cfg: any;
+  data: any;
+  meta: any;
+}
+
+export default function LegajoHeader({ cfg, data, meta }: Props) {
+  const ctx = { data, meta, ...meta };
+  return (
+    <div className="p-4 rounded bg-white shadow">
+      {cfg.title && (
+        <h1 className="text-2xl font-semibold">
+          {renderTpl(cfg.title, ctx)}
+        </h1>
+      )}
+      {cfg.subtitle && (
+        <div className="text-sm text-gray-500">{cfg.subtitle}</div>
+      )}
+      {Array.isArray(cfg.chips) && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {cfg.chips.map((c: any, i: number) => (
+            <span key={i} className="px-2 py-1 bg-gray-100 rounded text-sm">
+              {c.label}: {renderTpl(c.value, ctx)}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,2 @@
+export const enableVisualLegajo =
+  process.env.NEXT_PUBLIC_ENABLE_VISUAL_LEGAJO === 'true';

--- a/frontend/src/lib/services/plantillas.ts
+++ b/frontend/src/lib/services/plantillas.ts
@@ -54,6 +54,9 @@ export const PlantillasService = {
       http(`/formularios/${id}/`, { method: 'PUT', body: JSON.stringify(payload) })
     ),
 
+  updateVisualConfig: (id: string, cfg: any) =>
+    http(`/plantillas/${id}/visual-config/`, { method: 'PATCH', body: JSON.stringify(cfg) }),
+
   deletePlantilla: (id: string) =>
     http(`/plantillas/${id}/`, { method: 'DELETE' }).catch(() =>
       http(`/formularios/${id}/`, { method: 'DELETE' })

--- a/frontend/src/lib/store/usePlantillaVisualStore.ts
+++ b/frontend/src/lib/store/usePlantillaVisualStore.ts
@@ -1,0 +1,12 @@
+'use client';
+import { create } from 'zustand';
+
+interface VisualState {
+  visualConfig: any;
+  setVisualConfig: (cfg: any) => void;
+}
+
+export const useVisualConfigStore = create<VisualState>((set) => ({
+  visualConfig: {},
+  setVisualConfig: (cfg) => set({ visualConfig: cfg }),
+}));

--- a/frontend/src/lib/tpl.ts
+++ b/frontend/src/lib/tpl.ts
@@ -1,0 +1,11 @@
+export function renderTpl(tpl: string, ctx: any) {
+  if (typeof tpl !== 'string') return '';
+  return tpl.replace(/{{\s*([^}]+)\s*}}/g, (_, path) => {
+    const parts = path.trim().split('.');
+    let val = ctx;
+    for (const p of parts) {
+      val = val?.[p];
+    }
+    return val === undefined || val === null ? '' : String(val);
+  });
+}


### PR DESCRIPTION
## Summary
- add optional visual_config to Plantilla and API to persist it
- compute Legajo meta data and expose visual configuration
- UI builders and legajo page render visual mode when enabled

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c801371068832d8b1454b14ad24ae1