### PR TITLE
feat: support ui nodes in legajo builder

### DIFF
--- a/frontend/src/app/legajos/[id]/page.tsx
+++ b/frontend/src/app/legajos/[id]/page.tsx
@@ -1,71 +1,17 @@
-import { LegajosService } from '@/lib/services/legajos';
-import { enableVisualLegajo } from '@/lib/config';
-import LegajoHeader from '@/components/legajo/LegajoHeader';
-import CounterGrid from '@/components/legajo/CounterGrid';
-void [LegajosService, enableVisualLegajo, LegajoHeader, CounterGrid];
+import SectionRenderer from '@/components/legajo/SectionRenderer';
 
 export default async function LegajoDetallePage({ params }: { params: { id: string } }) {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/legajos/${params.id}`, {
     cache: 'no-store',
   });
-  const { data, visual_config, meta } = await res.json();
-  const hasVisual = !!(visual_config && Object.keys(visual_config).length);
-
-  const cfg = visual_config || {};
-
-  function getPath(obj: any, path?: string) {
-    if (!obj || !path) return '';
-    return path.split('.').reduce((o, k) => (o as any)?.[k], obj) ?? '';
-  }
-  function tpl(tplStr: string, ctx: any) {
-    return (tplStr || '').replace(/{{\s*([^}]+)\s*}}/g, (_, p) => String(getPath(ctx, p.trim())));
-  }
-
-  if (!hasVisual) {
-    return (
-      <div className="space-y-4">
-        <h1 className="text-2xl font-semibold">Legajo</h1>
-        <div className="space-y-1 text-sm">
-          <div>
-            <strong>Plantilla:</strong> {meta?.plantilla || ''}
-          </div>
-        </div>
-        <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto">{JSON.stringify(data, null, 2)}</pre>
-      </div>
-    );
-  }
+  const { data, schema, meta } = await res.json();
+  const sections = schema?.nodes || schema?.sections || [];
 
   return (
     <div className="space-y-8">
-      {cfg.header ? (
-        <div className="rounded-xl border p-6">
-          <h1 className="text-2xl font-semibold">
-            {tpl(cfg.header.title || '', { data, meta })}
-          </h1>
-          {cfg.header.subtitle && (
-            <p className="text-slate-600">{cfg.header.subtitle}</p>
-          )}
-        </div>
-      ) : null}
-
-      {cfg.counters?.items?.length ? (
-        <div
-          className="grid gap-3"
-          style={{ gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))' }}
-        >
-          {cfg.counters.items.map((c: any) => (
-            <div key={c.id} className="rounded-lg border p-4">
-              <div className="text-sm text-slate-500">{c.label}</div>
-              <div className="text-2xl font-semibold">
-                {tpl(c.value || '', { data, meta })}
-              </div>
-              {c.trend && <div className="text-xs text-slate-500">{c.trend}</div>}
-            </div>
-          ))}
-        </div>
-      ) : null}
-
-      {/* …aquí sigue tu render clásico de secciones/campos */}
+      {sections.map((s: any) => (
+        <SectionRenderer key={s.id} section={s} ctx={{ data, meta }} />
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/form/builder/ComponentsModal.tsx
+++ b/frontend/src/components/form/builder/ComponentsModal.tsx
@@ -16,6 +16,16 @@ const GROUPS: Record<string,[FieldType,string][]> = {
   ],
 };
 
+const ESTETICA = [
+  { type: "ui:header", label: "Encabezado" },
+  { type: "ui:kpi-grid", label: "Contadores / KPIs" },
+  { type: "ui:divider", label: "Separador" },
+  { type: "ui:banner", label: "Banner" },
+  { type: "ui:summary-pinned", label: "Resumen (pinned)" },
+  { type: "ui:attachments", label: "Archivos" },
+  { type: "ui:timeline", label: "Timeline" },
+];
+
 export default function ComponentsModal({ open, onClose }:{open:boolean; onClose:()=>void}) {
   const { addField, getSectionIdForInsert } = useBuilderStore();
 
@@ -52,6 +62,22 @@ export default function ComponentsModal({ open, onClose }:{open:boolean; onClose
               </div>
             </div>
           ))}
+
+          <section className="mt-6">
+            <h4 className="text-sm font-semibold mb-2">Estética</h4>
+            <div className="grid gap-2" style={{gridTemplateColumns:"repeat(auto-fit,minmax(220px,1fr))"}}>
+              {ESTETICA.map((c) => (
+                <button
+                  key={c.type}
+                  type="button"
+                  className="border rounded-md h-10 px-3 text-left"
+                  onClick={() => insert(c.type)}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+          </section>
         </div>
         <div className="text-right mt-4">
           <button onClick={onClose} className="px-3 py-2 border rounded-xl dark:border-slate-700">Cerrar</button>

--- a/frontend/src/components/form/builder/FieldCard.tsx
+++ b/frontend/src/components/form/builder/FieldCard.tsx
@@ -2,6 +2,9 @@
 import { useBuilderStore } from '@/lib/store/usePlantillaBuilderStore';
 
 function MiniPreview({ node }: { node: any }) {
+  if (node.kind === 'ui' || String(node.type || '').startsWith('ui:')) {
+    return <div className="font-medium text-slate-500">{node.type}</div>;
+  }
   const label = node.label || 'Sin título';
   switch (node.type) {
     case 'text':

--- a/frontend/src/components/form/builder/FieldPropertiesModal.tsx
+++ b/frontend/src/components/form/builder/FieldPropertiesModal.tsx
@@ -53,169 +53,175 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
         </div>
 
         <div className="space-y-3 max-h-[65vh] overflow-auto pr-1">
-          {/* Comunes */}
-          <Row label="Etiqueta">
-            <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.label || ''}
-                   onChange={(e) => setDraft((d: any) => ({ ...d, label: e.target.value }))} />
-          </Row>
-          <Row label="Key">
-            <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={draft.key || ''}
-                   onChange={(e) => setDraft((d: any) => ({ ...d, key: e.target.value }))} />
-          </Row>
-          <Row label="Obligatorio">
-            <input type="checkbox" checked={!!draft.required}
-                   onChange={(e) => setDraft((d: any) => ({ ...d, required: e.target.checked }))} />
-          </Row>
-          <Row label="Subsanable">
-            <input type="checkbox" checked={!!draft.esSubsanable}
-                   onChange={(e) => setDraft((d: any) => ({ ...d, esSubsanable: e.target.checked }))} />
-          </Row>
-          <Row label="Editable operador">
-            <input type="checkbox" checked={!!draft.esEditableOperador}
-                   onChange={(e) => setDraft((d: any) => ({ ...d, esEditableOperador: e.target.checked }))} />
-          </Row>
-          <Row label="En grilla">
-            <input type="checkbox" checked={!!draft.seMuestraEnGrilla}
-                   onChange={(e) => setDraft((d: any) => ({ ...d, seMuestraEnGrilla: e.target.checked }))} />
-          </Row>
-
-          {/* Específicas por tipo */}
-          {(draft.type === 'text' || draft.type === 'textarea') && (
+          {draft.kind === 'ui' ? (
+            <UiInspector node={draft} onChange={(patch:any)=>setDraft((d:any)=>({...d, ...patch}))} />
+          ) : (
             <>
-              <Row label="Placeholder">
-                <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.placeholder || ''}
-                       onChange={(e) => setDraft((d: any) => ({ ...d, placeholder: e.target.value }))} />
+              {/* Comunes */}
+              <Row label="Etiqueta">
+                <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.label || ''}
+                       onChange={(e) => setDraft((d: any) => ({ ...d, label: e.target.value }))} />
               </Row>
-              <Row label="Máx. largo">
-                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.maxLength ?? ''}
-                       onChange={(e) => setDraft((d: any) => ({ ...d, maxLength: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+              <Row label="Key">
+                <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={draft.key || ''}
+                       onChange={(e) => setDraft((d: any) => ({ ...d, key: e.target.value }))} />
               </Row>
-              <Row label="Regex">
-                <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={draft.pattern || ''}
-                       onChange={(e) => setDraft((d: any) => ({ ...d, pattern: e.target.value }))} />
+              <Row label="Obligatorio">
+                <input type="checkbox" checked={!!draft.required}
+                       onChange={(e) => setDraft((d: any) => ({ ...d, required: e.target.checked }))} />
               </Row>
-            </>
-          )}
+              <Row label="Subsanable">
+                <input type="checkbox" checked={!!draft.esSubsanable}
+                       onChange={(e) => setDraft((d: any) => ({ ...d, esSubsanable: e.target.checked }))} />
+              </Row>
+              <Row label="Editable operador">
+                <input type="checkbox" checked={!!draft.esEditableOperador}
+                       onChange={(e) => setDraft((d: any) => ({ ...d, esEditableOperador: e.target.checked }))} />
+              </Row>
+              <Row label="En grilla">
+                <input type="checkbox" checked={!!draft.seMuestraEnGrilla}
+                       onChange={(e) => setDraft((d: any) => ({ ...d, seMuestraEnGrilla: e.target.checked }))} />
+              </Row>
 
-          {draft.type === 'number' && (
-            <>
-              <Row label="Mínimo">
-                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.min ?? ''}
-                       onChange={(e) => setDraft((d: any) => ({ ...d, min: e.target.value === '' ? undefined : Number(e.target.value) }))} />
-              </Row>
-              <Row label="Máximo">
-                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.max ?? ''}
-                       onChange={(e) => setDraft((d: any) => ({ ...d, max: e.target.value === '' ? undefined : Number(e.target.value) }))} />
-              </Row>
-              <Row label="Step">
-                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.step ?? ''}
-                       onChange={(e) => setDraft((d: any) => ({ ...d, step: e.target.value === '' ? undefined : Number(e.target.value) }))} />
-              </Row>
-            </>
-          )}
+              {/* Específicas por tipo */}
+              {(draft.type === 'text' || draft.type === 'textarea') && (
+                <>
+                  <Row label="Placeholder">
+                    <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.placeholder || ''}
+                           onChange={(e) => setDraft((d: any) => ({ ...d, placeholder: e.target.value }))} />
+                  </Row>
+                  <Row label="Máx. largo">
+                    <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.maxLength ?? ''}
+                           onChange={(e) => setDraft((d: any) => ({ ...d, maxLength: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+                  </Row>
+                  <Row label="Regex">
+                    <input className="w-full border rounded p-2 font-mono dark:bg-slate-900 dark:border-slate-700" value={draft.pattern || ''}
+                           onChange={(e) => setDraft((d: any) => ({ ...d, pattern: e.target.value }))} />
+                  </Row>
+                </>
+              )}
 
-          {['select', 'dropdown', 'multiselect', 'select_with_filter'].includes(draft.type) && (
-            <div className="space-y-2">
-              <div className="text-sm font-medium">Opciones</div>
-              {(draft.options || []).map((o: any, i: number) => (
-                <div key={i} className="flex gap-2">
-                  <input className="border rounded p-2 flex-1" value={o.label}
-                         onChange={(e) => {
-                           const options = [...(draft.options || [])];
-                           options[i] = { ...o, label: e.target.value };
-                           setDraft((d: any) => ({ ...d, options }));
-                         }} />
-                  <input className="border rounded p-2 w-40 font-mono" value={o.value}
-                         onChange={(e) => {
-                           const options = [...(draft.options || [])];
-                           options[i] = { ...o, value: e.target.value };
-                           setDraft((d: any) => ({ ...d, options }));
-                         }} />
-                  <button className="px-2 border rounded" onClick={() => {
-                    const options = [...(draft.options || [])];
-                    options.splice(i, 1);
-                    setDraft((d: any) => ({ ...d, options }));
-                  }}>−</button>
+              {draft.type === 'number' && (
+                <>
+                  <Row label="Mínimo">
+                    <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.min ?? ''}
+                           onChange={(e) => setDraft((d: any) => ({ ...d, min: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+                  </Row>
+                  <Row label="Máximo">
+                    <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.max ?? ''}
+                           onChange={(e) => setDraft((d: any) => ({ ...d, max: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+                  </Row>
+                    <Row label="Step">
+                    <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.step ?? ''}
+                           onChange={(e) => setDraft((d: any) => ({ ...d, step: e.target.value === '' ? undefined : Number(e.target.value) }))} />
+                  </Row>
+                </>
+              )}
+
+              {['select', 'dropdown', 'multiselect', 'select_with_filter'].includes(draft.type) && (
+                <div className="space-y-2">
+                  <div className="text-sm font-medium">Opciones</div>
+                  {(draft.options || []).map((o: any, i: number) => (
+                    <div key={i} className="flex gap-2">
+                      <input className="border rounded p-2 flex-1" value={o.label}
+                             onChange={(e) => {
+                               const options = [...(draft.options || [])];
+                               options[i] = { ...o, label: e.target.value };
+                               setDraft((d: any) => ({ ...d, options }));
+                             }} />
+                      <input className="border rounded p-2 w-40 font-mono" value={o.value}
+                             onChange={(e) => {
+                               const options = [...(draft.options || [])];
+                               options[i] = { ...o, value: e.target.value };
+                               setDraft((d: any) => ({ ...d, options }));
+                             }} />
+                      <button className="px-2 border rounded" onClick={() => {
+                        const options = [...(draft.options || [])];
+                        options.splice(i, 1);
+                        setDraft((d: any) => ({ ...d, options }));
+                      }}>−</button>
+                    </div>
+                  ))}
+                  <button className="px-2 py-1 border rounded"
+                          onClick={() => setDraft((d: any) => ({
+                            ...d,
+                            options: [...(d.options || []), { label: 'Opción', value: `op_${(d.options?.length || 0) + 1}` }]
+                          }))}>
+                    + Agregar opción
+                  </button>
                 </div>
-              ))}
-              <button className="px-2 py-1 border rounded"
-                      onClick={() => setDraft((d: any) => ({
-                        ...d,
-                        options: [...(d.options || []), { label: 'Opción', value: `op_${(d.options?.length || 0) + 1}` }]
-                      }))}>
-                + Agregar opción
-              </button>
-            </div>
-          )}
+              )}
 
-          {draft.type === 'document' && (
-            <>
-              <Row label="Extensiones">
-                <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" placeholder=".pdf,.jpg"
-                       value={(draft.accept || []).join(',')}
-                       onChange={(e) => setDraft((d: any) => ({
-                         ...d,
-                         accept: e.target.value.split(',').map((s) => s.trim()).filter(Boolean)
-                       }))} />
-              </Row>
-              <Row label="Tamaño MB">
-                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.maxSizeMB ?? ''}
-                       onChange={(e) => setDraft((d: any) => ({
-                         ...d, maxSizeMB: e.target.value === '' ? undefined : Number(e.target.value)
-                       }))} />
-              </Row>
+              {draft.type === 'document' && (
+                <>
+                  <Row label="Extensiones">
+                    <input className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" placeholder=".pdf,.jpg"
+                           value={(draft.accept || []).join(',')}
+                           onChange={(e) => setDraft((d: any) => ({
+                             ...d,
+                             accept: e.target.value.split(',').map((s) => s.trim()).filter(Boolean)
+                           }))} />
+                  </Row>
+                  <Row label="Tamaño MB">
+                    <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.maxSizeMB ?? ''}
+                           onChange={(e) => setDraft((d: any) => ({
+                             ...d, maxSizeMB: e.target.value === '' ? undefined : Number(e.target.value)
+                           }))} />
+                  </Row>
+                </>
+              )}
+
+              {draft.type === 'sum' && (
+                <>
+                  <Row label="Decimales">
+                    <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.decimals ?? 0}
+                           onChange={(e) => setDraft((d: any) => ({ ...d, decimals: Number(e.target.value) || 0 }))} />
+                  </Row>
+                  <div>
+                    <div className="text-sm opacity-70 mb-1">Fuentes (solo números)</div>
+                    <div className="flex flex-wrap gap-2">
+                      {numKeys.map((k) => {
+                        const active = (draft.sources || []).includes(k);
+                        return (
+                          <button
+                            key={k}
+                            type="button"
+                            className={`px-2 py-1 border rounded text-xs ${active ? 'bg-sky-100 border-sky-300' : ''}`}
+                            onClick={() => {
+                              const set = new Set(draft.sources || []);
+                              if (active) set.delete(k); else set.add(k);
+                              setDraft((d: any) => ({ ...d, sources: Array.from(set) }));
+                            }}
+                          >
+                            {k}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {draft.type === 'date' && (
+                <>
+                  <Row label="Default relativo">
+                    <input
+                      className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700"
+                      placeholder="e.g. +0 days"
+                      value={draft.defaultRelative || ''}
+                      onChange={(e) => setDraft((d: any) => ({ ...d, defaultRelative: e.target.value }))}
+                    />
+                  </Row>
+                </>
+              )}
+
+              {draft.type === 'info' && (
+                <Row label="HTML">
+                  <textarea className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" rows={3} value={draft.html || ''}
+                            onChange={(e) => setDraft((d: any) => ({ ...d, html: e.target.value }))} />
+                </Row>
+              )}
             </>
-          )}
-
-          {draft.type === 'sum' && (
-            <>
-              <Row label="Decimales">
-                <input type="number" className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" value={draft.decimals ?? 0}
-                       onChange={(e) => setDraft((d: any) => ({ ...d, decimals: Number(e.target.value) || 0 }))} />
-              </Row>
-              <div>
-                <div className="text-sm opacity-70 mb-1">Fuentes (solo números)</div>
-                <div className="flex flex-wrap gap-2">
-                  {numKeys.map((k) => {
-                    const active = (draft.sources || []).includes(k);
-                    return (
-                      <button
-                        key={k}
-                        type="button"
-                        className={`px-2 py-1 border rounded text-xs ${active ? 'bg-sky-100 border-sky-300' : ''}`}
-                        onClick={() => {
-                          const set = new Set(draft.sources || []);
-                          if (active) set.delete(k); else set.add(k);
-                          setDraft((d: any) => ({ ...d, sources: Array.from(set) }));
-                        }}
-                      >
-                        {k}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            </>
-          )}
-
-          {draft.type === 'date' && (
-            <>
-              <Row label="Default relativo">
-                <input
-                  className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700"
-                  placeholder="e.g. +0 days"
-                  value={draft.defaultRelative || ''}
-                  onChange={(e) => setDraft((d: any) => ({ ...d, defaultRelative: e.target.value }))}
-                />
-              </Row>
-            </>
-          )}
-
-          {draft.type === 'info' && (
-            <Row label="HTML">
-              <textarea className="w-full border rounded p-2 dark:bg-slate-900 dark:border-slate-700" rows={3} value={draft.html || ''}
-                        onChange={(e) => setDraft((d: any) => ({ ...d, html: e.target.value }))} />
-            </Row>
           )}
         </div>
 
@@ -226,4 +232,73 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
       </div>
     </div>
   );
+}
+
+function UiInspector({ node, onChange }: any) {
+  const cfg = node.config || {};
+  if (node.type === 'ui:header') {
+    return (
+      <div className="space-y-3">
+        <label className="block text-sm">Variante
+          <select
+            className="border rounded-md h-10 px-2 w-full"
+            value={cfg.variant ?? 'card'}
+            onChange={(e)=>onChange({ config: { ...cfg, variant: e.target.value } })}
+          >
+            <option value="hero">hero</option>
+            <option value="card">card</option>
+            <option value="compact">compact</option>
+          </select>
+        </label>
+        <label className="block text-sm">Título (plantilla)
+          <input className="border rounded-md h-10 px-2 w-full"
+            value={cfg.title ?? ''}
+            onChange={(e)=>onChange({ config: { ...cfg, title: e.target.value } })}
+            placeholder='{{ data.ciudadano.apellido }}, {{ data.ciudadano.nombre }}'
+          />
+        </label>
+        <label className="block text-sm">Subtítulo
+          <input className="border rounded-md h-10 px-2 w-full"
+            value={cfg.subtitle ?? ''}
+            onChange={(e)=>onChange({ config: { ...cfg, subtitle: e.target.value } })}
+          />
+        </label>
+      </div>
+    );
+  }
+
+  if (node.type === 'ui:kpi-grid') {
+    const items = cfg.items ?? [];
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm">KPIs</span>
+          <button type="button" className="h-8 px-2 border rounded"
+            onClick={()=>onChange({ config: { ...cfg, items: [...items, { id: crypto.randomUUID(), label:'Nuevo KPI', value:'{{ meta.counts.intervenciones }}' }] } })}
+          >Agregar</button>
+        </div>
+        {items.map((it:any, i:number)=>(
+          <div key={it.id} className="grid gap-2" style={{gridTemplateColumns:"1fr 1fr auto"}}>
+            <input className="border rounded h-9 px-2" value={it.label}
+              onChange={(e)=>{
+                const copy=[...items]; copy[i]={...it, label:e.target.value};
+                onChange({ config: { ...cfg, items: copy } });
+              }}/>
+            <input className="border rounded h-9 px-2" value={it.value}
+              onChange={(e)=>{
+                const copy=[...items]; copy[i]={...it, value:e.target.value};
+                onChange({ config: { ...cfg, items: copy } });
+              }}/>
+            <button type="button" className="h-9 px-2 border rounded"
+              onClick={()=>{
+                const copy=items.filter((_:any,idx:number)=>idx!==i);
+                onChange({ config: { ...cfg, items: copy } });
+              }}>Eliminar</button>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return <div className="text-sm text-slate-500">Seleccioná un bloque de estética para configurarlo.</div>;
 }

--- a/frontend/src/components/form/builder/zodFromTemplate.ts
+++ b/frontend/src/components/form/builder/zodFromTemplate.ts
@@ -35,6 +35,8 @@ function flatten(raw: any): Node[] {
   return [];
 }
 
+function isUiNode(n:any){ return n?.kind === "ui" || String(n?.type||"").startsWith("ui:"); }
+
 function safeName(n: Node, idx: number, used: Set<string>) {
   let base =
     n.key ||
@@ -114,14 +116,15 @@ function schemaForNode(n: Node): z.ZodTypeAny {
 }
 
 export function zodFromTemplate(rawNodes: any): z.ZodObject<any> {
-  const nodes = flatten(rawNodes);
+  const nodes = flatten(rawNodes).filter((n:any)=> !isUiNode(n));
   const used = new Set<string>();
   const shape: Record<string, z.ZodTypeAny> = {};
 
   nodes.forEach((n: Node, idx: number) => {
     // Soporte de grupos: si trae children/nodes/fields, flatearlos como hermanos
-    const children = flatten(n) // si n es sección con nodes/fields
-      .concat(n.children || []);
+    const children = flatten(n)
+      .concat(n.children || [])
+      .filter((c:any)=> !isUiNode(c));
     if (children.length) {
       children.forEach((c, i) => {
         const name = safeName(c, i, used);

--- a/frontend/src/components/form/runtime/DynamicForm.tsx
+++ b/frontend/src/components/form/runtime/DynamicForm.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { zodFromTemplate } from "../builder/zodFromTemplate";
+import DynamicNode from "./DynamicNode";
 import { Button } from "@/components/ui/button";
 
 // Normaliza distintos formatos y hace fallback seguro
@@ -19,6 +20,8 @@ function normalizeSchema(raw: any): { nodes: any[] } {
   return { nodes: [] };
 }
 
+function isUiNode(n:any){ return n?.kind === "ui" || String(n?.type||"").startsWith("ui:"); }
+
 export default function DynamicForm({
   schema,
   onSubmit,
@@ -27,9 +30,10 @@ export default function DynamicForm({
   onSubmit: (data: any) => void;
 }) {
   const normalized = useMemo(() => normalizeSchema(schema), [schema]);
+  const nodes = useMemo(()=> (normalized.nodes || []).filter((n:any)=> !isUiNode(n)), [normalized.nodes]);
   const zodSchema = useMemo(
-    () => zodFromTemplate(normalized.nodes || []),
-    [normalized.nodes]
+    () => zodFromTemplate(nodes),
+    [nodes]
   );
 
   const methods = useForm({
@@ -61,8 +65,7 @@ export default function DynamicForm({
         className="space-y-4"
         noValidate
       >
-        {/* acá renderizás tus inputs a partir de normalized.nodes */}
-        {/* <DynamicFields nodes={normalized.nodes} /> */}
+        {nodes.map((n:any)=> <DynamicNode key={n.id} node={n} />)}
 
         <div className="pt-2">
           <Button type="submit">Guardar</Button>

--- a/frontend/src/components/form/runtime/DynamicNode.tsx
+++ b/frontend/src/components/form/runtime/DynamicNode.tsx
@@ -11,6 +11,8 @@ import CuitRazonSocialField from "./fields/CuitRazonSocialField";
 import InfoField from "./fields/InfoField";
 import GroupField from "./fields/GroupField";
 
+function isUiNode(n:any){ return n?.kind==='ui' || String(n?.type||'').startsWith('ui:'); }
+
 export default function DynamicNode({ node, prefix="" }:{node:any, prefix?:string}) {
   const { control } = useFormContext();
   const allValues = useWatch({ control });
@@ -18,6 +20,7 @@ export default function DynamicNode({ node, prefix="" }:{node:any, prefix?:strin
   const hidden = node.condicionesOcultar ? evalConditions(allValues, node.condicionesOcultar) : false;
   if (hidden) return null;
 
+  if (isUiNode(node)) return null;
   if (node.type === "section") {
     return (
       <fieldset className="rounded-2xl border p-4 space-y-3">

--- a/frontend/src/components/legajo/SectionRenderer.tsx
+++ b/frontend/src/components/legajo/SectionRenderer.tsx
@@ -1,0 +1,55 @@
+import * as Icons from "lucide-react";
+function isUiNode(n:any){ return n?.kind==="ui" || String(n?.type||"").startsWith("ui:"); }
+
+function getPath(obj:any, path?:string){ if(!obj || !path) return ""; return path.split(".").reduce((o:any,k:string)=>o?.[k], obj) ?? ""; }
+function tpl(tplStr:string, ctx:any){ return (tplStr||"").replace(/{{\s*([^}]+)\s*}}/g,(_,p)=> String(getPath(ctx,p.trim())) ); }
+
+function FieldReadOnly({ node, ctx }:{ node:any; ctx:any }) {
+  return <div>{node.label || node.key}</div>;
+}
+const AttachmentsCard = (props:any)=> <div className="text-sm text-slate-500">Archivos</div>;
+const Timeline = (props:any)=> <div className="text-sm text-slate-500">Timeline</div>;
+const SummaryPinned = ({cfg, ctx}:{cfg:any; ctx:any})=> <div className="text-sm text-slate-500">Resumen</div>;
+
+export function SectionRenderer({ section, ctx }:{ section:any; ctx:any }) {
+  return (
+    <div className="space-y-4">
+      {section.nodes.map((n:any)=>{
+        if (isUiNode(n)) return <UiBlock key={n.id} node={n} ctx={ctx} />;
+        return <FieldReadOnly key={n.id} node={n} ctx={ctx} />;
+      })}
+    </div>
+  );
+}
+
+function UiBlock({ node, ctx }:{ node:any; ctx:any }) {
+  const cfg = node.config || {};
+  if (node.type === "ui:header") {
+    return (
+      <header className="rounded-2xl p-6 text-white bg-gradient-to-r from-indigo-600 to-sky-500">
+        <h1 className="text-2xl font-semibold">{tpl(cfg.title, ctx)}</h1>
+        {cfg.subtitle && <p className="opacity-80">{cfg.subtitle}</p>}
+      </header>
+    );
+  }
+  if (node.type === "ui:kpi-grid") {
+    const items = cfg.items ?? [];
+    return (
+      <div className="grid gap-3" style={{gridTemplateColumns:"repeat(auto-fit,minmax(180px,1fr))"}}>
+        {items.map((it:any)=>(
+          <div key={it.id} className="rounded-lg border p-4">
+            <div className="text-sm text-slate-500">{it.label}</div>
+            <div className="text-2xl font-semibold">{tpl(it.value, ctx)}</div>
+            {it.trend && <div className="text-xs text-slate-500">{it.trend}</div>}
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (node.type === "ui:divider") return <hr className="my-6 border-slate-200" />;
+  if (node.type === "ui:banner") return <div className="rounded-md border p-4 bg-sky-50 text-sky-900">{cfg.text}</div>;
+  if (node.type === "ui:attachments") return <AttachmentsCard />;
+  if (node.type === "ui:timeline") return <Timeline />;
+  if (node.type === "ui:summary-pinned") return <SummaryPinned cfg={cfg} ctx={ctx} />;
+  return null;
+}

--- a/frontend/src/lib/form-builder/factory.ts
+++ b/frontend/src/lib/form-builder/factory.ts
@@ -49,3 +49,52 @@ export function newField(type: FieldType) {
     options: [{ value:"opcion_1", label:"Opción 1" }],
   };
 }
+
+export function createNode(type: string) {
+  if (type.startsWith("ui:")) return createUiNode(type);
+  return newField(type as FieldType);
+}
+
+function createUiNode(type: string) {
+  switch (type) {
+    case "ui:header":
+      return {
+        id: crypto.randomUUID(),
+        kind: "ui",
+        type,
+        config: {
+          variant: "hero",
+          title: "{{ data.ciudadano.apellido }}, {{ data.ciudadano.nombre }}",
+          subtitle: "Legajo de Ciudadano",
+          show_photo: true,
+        },
+      };
+    case "ui:kpi-grid":
+      return {
+        id: crypto.randomUUID(),
+        kind: "ui",
+        type,
+        config: {
+          layout: "grid-4",
+          items: [
+            { id: "kpi1", label: "Intervenciones", value: "{{ meta.counts.intervenciones }}" },
+            { id: "kpi2", label: "Archivos", value: "{{ meta.counts.archivos }}" },
+            { id: "kpi3", label: "Alertas", value: "{{ meta.counts.alertas_activas }}" },
+            { id: "kpi4", label: "Completitud", value: "{{ meta.completitud }}%" },
+          ],
+        },
+      };
+    case "ui:divider":
+      return { id: crypto.randomUUID(), kind: "ui", type, config: { label: "Sección", subtle: true } };
+    case "ui:banner":
+      return { id: crypto.randomUUID(), kind: "ui", type, config: { intent: "info", text: "Mensaje" } };
+    case "ui:summary-pinned":
+      return { id: crypto.randomUUID(), kind: "ui", type, config: { fields: [] } };
+    case "ui:attachments":
+      return { id: crypto.randomUUID(), kind: "ui", type, config: { allow_preview: true } };
+    case "ui:timeline":
+      return { id: crypto.randomUUID(), kind: "ui", type, config: { dense: false } };
+    default:
+      return { id: crypto.randomUUID(), kind: "ui", type, config: {} };
+  }
+}


### PR DESCRIPTION
## Summary
- add "Estética" palette and default node factory for `ui:` components
- ignore and configure `ui:` nodes through inspector and form runtime
- render visual blocks in legajo via new `SectionRenderer`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c832fd32c4832d85c7c6b33dc14ebb