### PR TITLE
Add grid layout support for plantilla sections

### DIFF
--- a/frontend/src/components/form/builder/FieldPropertiesModal.tsx
+++ b/frontend/src/components/form/builder/FieldPropertiesModal.tsx
@@ -11,9 +11,10 @@ export default function FieldPropertiesModal({ open, fieldId, onClose }: Props) 
   const node = useMemo(() => {
     if (!fieldId) return null;
     for (const s of sections) {
-      const direct = (s.children || []).find((n: any) => n.id === fieldId);
+      const list = s.nodes || s.children || [];
+      const direct = list.find((n: any) => n.id === fieldId);
       if (direct) return direct;
-      const grp = (s.children || []).find(
+      const grp = list.find(
         (n: any) => n.type === 'group' && (n.children || []).some((c: any) => c.id === fieldId)
       );
       if (grp) return (grp.children || []).find((c: any) => c.id === fieldId);

--- a/frontend/src/components/form/builder/PropertiesPanel.tsx
+++ b/frontend/src/components/form/builder/PropertiesPanel.tsx
@@ -16,9 +16,10 @@ export default function PropertiesPanel() {
   const node = useMemo(()=>{
     if (!selected || selected.type!=='field') return null;
     for (const s of sections) {
-      const hit = (s.children||[]).find((n:any)=>n.id===selected.id);
+      const list = s.nodes || s.children || [];
+      const hit = list.find((n:any)=>n.id===selected.id);
       if (hit) return hit;
-      const g = (s.children||[]).find((n:any)=>n.type==='group' && (n.children||[]).some((c:any)=>c.id===selected.id));
+      const g = list.find((n:any)=>n.type==='group' && (n.children||[]).some((c:any)=>c.id===selected.id));
       if (g) return (g.children||[]).find((c:any)=>c.id===selected.id);
     }
     return null;

--- a/frontend/src/components/legajo/SectionGridView.tsx
+++ b/frontend/src/components/legajo/SectionGridView.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { Layout } from "react-grid-layout";
+import { useMemo } from "react";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+const RGL = dynamic(async () => {
+  const mod: any = await import("react-grid-layout");
+  return mod.WidthProvider(mod.default);
+}, { ssr: false });
+
+type Props = {
+  section: any;
+  ctx: any;
+  renderField: (node: any, ctx: any) => React.ReactNode;
+  renderUi: (node: any, ctx: any) => React.ReactNode;
+};
+
+export default function SectionGridView({ section, ctx, renderField, renderUi }: Props) {
+  const nodes = section?.nodes || section?.children || [];
+  const layout = useMemo<Layout[]>(() => {
+    return nodes.map((n: any) => ({
+      i: n.layout?.i ?? n.id,
+      x: n.layout?.x ?? 0,
+      y: n.layout?.y ?? 0,
+      w: n.layout?.w ?? 6,
+      h: n.layout?.h ?? 3,
+    }));
+  }, [nodes]);
+
+  return (
+    <RGL
+      cols={12}
+      rowHeight={24}
+      margin={[12, 12]}
+      isDraggable={false}
+      isResizable={false}
+      compactType="vertical"
+      layout={layout}
+    >
+      {nodes.map((node: any) => {
+        const key = node.layout?.i ?? node.id;
+        const fallback = layout.find((l) => l.i === key) ?? { i: key, x: 0, y: 0, w: 6, h: 3 };
+        const dataGrid = node.layout ? { ...fallback, ...node.layout, i: key } : fallback;
+        return (
+          <div key={key} data-grid={dataGrid}>
+            {node.kind === "ui" || String(node.type || "").startsWith("ui:")
+              ? renderUi(node, ctx)
+              : renderField(node, ctx)}
+          </div>
+        );
+      })}
+    </RGL>
+  );
+}

--- a/frontend/src/components/legajo/SectionRenderer.tsx
+++ b/frontend/src/components/legajo/SectionRenderer.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import * as Icons from "lucide-react";
+import SectionGridView from "./SectionGridView";
+
 function isUiNode(n:any){ return n?.kind==="ui" || String(n?.type||"").startsWith("ui:"); }
 
 function getPath(obj:any, path?:string){ if(!obj || !path) return ""; return path.split(".").reduce((o:any,k:string)=>o?.[k], obj) ?? ""; }
@@ -11,10 +15,24 @@ const AttachmentsCard = (props:any)=> <div className="text-sm text-slate-500">Ar
 const Timeline = (props:any)=> <div className="text-sm text-slate-500">Timeline</div>;
 const SummaryPinned = ({cfg, ctx}:{cfg:any; ctx:any})=> <div className="text-sm text-slate-500">Resumen</div>;
 
-export function SectionRenderer({ section, ctx }:{ section:any; ctx:any }) {
+export default function SectionRenderer({ section, ctx }:{ section:any; ctx:any }) {
+  const nodes = section?.nodes || section?.children || [];
+  const layoutMode = section?.layout_mode === "grid" ? "grid" : "flow";
+
+  if (layoutMode === "grid") {
+    return (
+      <SectionGridView
+        section={{ ...section, nodes }}
+        ctx={ctx}
+        renderField={(node) => <FieldReadOnly node={node} ctx={ctx} />}
+        renderUi={(node) => <UiBlock node={node} ctx={ctx} />}
+      />
+    );
+  }
+
   return (
     <div className="space-y-4">
-      {section.nodes.map((n:any)=>{
+      {nodes.map((n:any)=>{
         if (isUiNode(n)) return <UiBlock key={n.id} node={n} ctx={ctx} />;
         return <FieldReadOnly key={n.id} node={n} ctx={ctx} />;
       })}
@@ -53,3 +71,5 @@ function UiBlock({ node, ctx }:{ node:any; ctx:any }) {
   if (node.type === "ui:summary-pinned") return <SummaryPinned cfg={cfg} ctx={ctx} />;
   return null;
 }
+
+export { SectionRenderer };

--- a/frontend/src/components/plantillas/SectionGridDesigner.tsx
+++ b/frontend/src/components/plantillas/SectionGridDesigner.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useMemo } from "react";
+import type { Layout } from "react-grid-layout";
+import { useBuilderStore } from "@/lib/store/usePlantillaBuilderStore";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+const RGL = dynamic(async () => {
+  const mod: any = await import("react-grid-layout");
+  return mod.WidthProvider(mod.default);
+}, { ssr: false });
+
+type Props = {
+  section: { id: string; nodes: any[] };
+  onUpdateNodes: (nodes: any[]) => void;
+};
+
+export default function SectionGridDesigner({ section, onUpdateNodes }: Props) {
+  const { selected, setSelected, duplicateNode, removeNode } = useBuilderStore();
+
+  const layout = useMemo<Layout[]>(() => {
+    return (section.nodes || []).map((n: any) => ({
+      i: n.layout?.i ?? n.id,
+      x: n.layout?.x ?? 0,
+      y: n.layout?.y ?? 0,
+      w: n.layout?.w ?? 6,
+      h: n.layout?.h ?? 3,
+    }));
+  }, [section.nodes]);
+
+  const updateFromLayout = useCallback((next: Layout[]) => {
+    const map = new Map(next.map((l) => [l.i, l]));
+    const nodes = (section.nodes || []).map((n: any) => {
+      const key = n.layout?.i ?? n.id;
+      const match = map.get(key) || map.get(n.id);
+      if (!match) return n;
+      return {
+        ...n,
+        layout: {
+          ...(n.layout || {}),
+          i: key,
+          x: match.x,
+          y: match.y,
+          w: match.w,
+          h: match.h,
+        },
+      };
+    });
+    onUpdateNodes(nodes);
+  }, [section.nodes, onUpdateNodes]);
+
+  const handleEdit = (id: string) => {
+    window.dispatchEvent(new CustomEvent("builder:open-props", { detail: { id } }));
+  };
+
+  return (
+    <RGL
+      cols={12}
+      rowHeight={24}
+      margin={[12, 12]}
+      compactType="vertical"
+      isDraggable
+      isResizable
+      layout={layout}
+      onLayoutChange={updateFromLayout}
+    >
+      {(section.nodes || []).map((node: any) => {
+        const key = node.layout?.i ?? node.id;
+        const isSelected = selected?.type === "field" && selected.id === node.id;
+        const title = node.config?.title || node.label || node.key || node.id;
+        return (
+          <div key={key} data-grid={node.layout}>
+            <div
+              className={`h-full w-full rounded-lg border bg-white p-3 shadow-sm transition ${
+                isSelected ? "ring-2 ring-sky-400" : "hover:border-sky-200"
+              }`}
+              onClick={() => setSelected({ type: "field", id: node.id })}
+            >
+              <div className="flex items-start justify-between gap-2 text-xs text-slate-500">
+                <span className="font-medium uppercase tracking-wide">{node.type}</span>
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    className="rounded border px-2 py-0.5"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleEdit(node.id);
+                    }}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded border px-2 py-0.5"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      duplicateNode(node.id);
+                    }}
+                  >
+                    Duplicar
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded border px-2 py-0.5 text-red-600"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeNode(node.id);
+                    }}
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              </div>
+              <div className="mt-2 text-sm font-medium truncate text-slate-700">
+                {title}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </RGL>
+  );
+}

--- a/frontend/src/lib/form-builder/factory.ts
+++ b/frontend/src/lib/form-builder/factory.ts
@@ -6,6 +6,19 @@ export type FieldType =
   | "date"|"document"|"sum"|"phone"|"cuit_razon_social"
   | "info"|"group";
 
+const LAYOUT_DEFAULTS: Record<string, { w: number; h: number }> = {
+  "ui:header": { w: 12, h: 5 },
+  "ui:kpi-grid": { w: 6, h: 4 },
+  "ui:divider": { w: 12, h: 1 },
+  "ui:banner": { w: 12, h: 3 },
+  "field:text": { w: 6, h: 3 },
+  "field:number": { w: 4, h: 3 },
+};
+
+export function defLayout(type: string) {
+  return LAYOUT_DEFAULTS[type] ?? LAYOUT_DEFAULTS[`field:${type}`] ?? { w: 6, h: 3 };
+}
+
 export function newField(type: FieldType) {
   const id = `fld_${nanoid(6)}`;
   const base = { id, label: "Sin título", required: false, esSubsanable: false, esEditableOperador: false, seMuestraEnGrilla: false } as any;
@@ -52,49 +65,60 @@ export function newField(type: FieldType) {
 
 export function createNode(type: string) {
   if (type.startsWith("ui:")) return createUiNode(type);
-  return newField(type as FieldType);
+
+  const node = newField(type as FieldType);
+  const { w, h } = defLayout(type);
+  const id = node.id ?? crypto.randomUUID();
+  return {
+    ...node,
+    id,
+    kind: "field",
+    layout: { i: id, x: 0, y: Number.POSITIVE_INFINITY, w, h },
+  };
 }
 
 function createUiNode(type: string) {
-  switch (type) {
-    case "ui:header":
-      return {
-        id: crypto.randomUUID(),
-        kind: "ui",
-        type,
-        config: {
-          variant: "hero",
-          title: "{{ data.ciudadano.apellido }}, {{ data.ciudadano.nombre }}",
-          subtitle: "Legajo de Ciudadano",
-          show_photo: true,
-        },
-      };
-    case "ui:kpi-grid":
-      return {
-        id: crypto.randomUUID(),
-        kind: "ui",
-        type,
-        config: {
-          layout: "grid-4",
-          items: [
-            { id: "kpi1", label: "Intervenciones", value: "{{ meta.counts.intervenciones }}" },
-            { id: "kpi2", label: "Archivos", value: "{{ meta.counts.archivos }}" },
-            { id: "kpi3", label: "Alertas", value: "{{ meta.counts.alertas_activas }}" },
-            { id: "kpi4", label: "Completitud", value: "{{ meta.completitud }}%" },
-          ],
-        },
-      };
-    case "ui:divider":
-      return { id: crypto.randomUUID(), kind: "ui", type, config: { label: "Sección", subtle: true } };
-    case "ui:banner":
-      return { id: crypto.randomUUID(), kind: "ui", type, config: { intent: "info", text: "Mensaje" } };
-    case "ui:summary-pinned":
-      return { id: crypto.randomUUID(), kind: "ui", type, config: { fields: [] } };
-    case "ui:attachments":
-      return { id: crypto.randomUUID(), kind: "ui", type, config: { allow_preview: true } };
-    case "ui:timeline":
-      return { id: crypto.randomUUID(), kind: "ui", type, config: { dense: false } };
-    default:
-      return { id: crypto.randomUUID(), kind: "ui", type, config: {} };
+  const id = crypto.randomUUID();
+  const { w, h } = defLayout(type);
+  const base = {
+    id,
+    kind: "ui" as const,
+    type,
+    layout: { i: id, x: 0, y: Number.POSITIVE_INFINITY, w, h },
+  };
+
+  if (type === "ui:header") {
+    return {
+      ...base,
+      config: {
+        variant: "hero",
+        show_photo: true,
+        title: "{{ data.ciudadano.apellido }}, {{ data.ciudadano.nombre }}",
+        subtitle: "Legajo de Ciudadano",
+      },
+    };
   }
+
+  if (type === "ui:kpi-grid") {
+    return {
+      ...base,
+      config: {
+        layout: "grid-4",
+        items: [
+          { id: "k1", label: "Intervenciones", value: "{{ meta.counts.intervenciones }}" },
+          { id: "k2", label: "Archivos", value: "{{ meta.counts.archivos }}" },
+          { id: "k3", label: "Alertas", value: "{{ meta.counts.alertas_activas }}" },
+          { id: "k4", label: "Completitud", value: "{{ meta.completitud }}%" },
+        ],
+      },
+    };
+  }
+
+  if (type === "ui:divider") return { ...base, config: { label: "Sección", subtle: true } };
+  if (type === "ui:banner") return { ...base, config: { intent: "info", text: "Mensaje" } };
+  if (type === "ui:summary-pinned") return { ...base, config: { fields: [] } };
+  if (type === "ui:attachments") return { ...base, config: { allow_preview: true } };
+  if (type === "ui:timeline") return { ...base, config: { dense: false } };
+
+  return { ...base, config: {} };
 }

--- a/frontend/src/lib/store/usePlantillaBuilderStore.ts
+++ b/frontend/src/lib/store/usePlantillaBuilderStore.ts
@@ -1,6 +1,6 @@
 'use client';
 import { create } from 'zustand';
-import { FieldType, createNode } from '@/lib/form-builder/factory';
+import { FieldType, createNode, defLayout } from '@/lib/form-builder/factory';
 import { arrayMove } from '@dnd-kit/sortable';
 
 
@@ -17,15 +17,58 @@ export type FieldNode = {
   kind?: string;
   key?: string;
   label?: string;
+  layout?: { i: string; x: number; y: number; w: number; h: number };
+  config?: any;
   [k: string]: any;
 };
 
 export type SectionNode = {
   id: string;
   title?: string;
-  children: FieldNode[];
+  nodes: FieldNode[];
+  children?: FieldNode[];
+  layout_mode?: 'flow' | 'grid';
   [k: string]: any;
 };
+
+const isUiNode = (node: any) => node?.kind === 'ui' || String(node?.type || '').startsWith('ui:');
+
+function ensureLayout(node: any): FieldNode {
+  const id = node.id ?? `fld_${crypto.randomUUID().slice(0, 6)}`;
+  const kind = node.kind ?? (isUiNode(node) ? 'ui' : 'field');
+  const baseLayout = node.layout ?? {};
+  const layoutDefaults = defLayout(node.type ?? '');
+  const layout = {
+    i: baseLayout.i ?? id,
+    x: typeof baseLayout.x === 'number' ? baseLayout.x : 0,
+    y: typeof baseLayout.y === 'number' ? baseLayout.y : Number.POSITIVE_INFINITY,
+    w: baseLayout.w ?? layoutDefaults.w,
+    h: baseLayout.h ?? layoutDefaults.h,
+  };
+  return { ...node, id, kind, layout };
+}
+
+function normalizeSection(section: any): SectionNode {
+  const nodes = (section?.nodes ?? section?.children ?? [])
+    .filter(Boolean)
+    .map((node: any) => ensureLayout(node));
+  const layout_mode: 'flow' | 'grid' = section?.layout_mode === 'grid' ? 'grid' : 'flow';
+  const normalized: SectionNode = {
+    ...section,
+    id: section?.id ?? `sec_${crypto.randomUUID().slice(0, 6)}`,
+    title: section?.title,
+    layout_mode,
+    nodes,
+    children: nodes,
+  };
+  return normalized;
+}
+
+function syncSection(section: SectionNode): SectionNode {
+  const nodes = (section.nodes || []).map((node) => ensureLayout(node));
+  const layout_mode: 'flow' | 'grid' = section.layout_mode === 'grid' ? 'grid' : 'flow';
+  return { ...section, layout_mode, nodes, children: nodes };
+}
 
 type Selected = { type: 'section' | 'field'; id: string } | null;
 
@@ -82,18 +125,31 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
   addSection: () => {
     const n = (get().sections?.length || 0) + 1;
     const id = `sec_${crypto.randomUUID().slice(0, 6)}`;
-    const section: SectionNode = { id, title: `Sección ${n}`, children: [] };
-    set((s) => ({
-      sections: [...(s.sections || []), section],
-      selected: { type: 'section', id },
-      dirty: true,
-    }));
+    const section: SectionNode = { id, title: `Sección ${n}`, nodes: [], children: [], layout_mode: 'flow' };
+    set((s) => {
+      const sections = [...(s.sections || []), syncSection(section)];
+      return {
+        sections,
+        selected: { type: 'section', id },
+        dirty: true,
+      };
+    });
     return id;
   },
 
   updateSection: (id, patch) =>
     set((state) => {
-      const sections = (state.sections || []).map((s: any) => (s.id === id ? { ...s, ...patch } : s));
+      const sections = (state.sections || []).map((s: SectionNode) => {
+        if (s.id !== id) return s;
+        const next: SectionNode = {
+          ...s,
+          ...patch,
+        };
+        if (patch?.nodes) {
+          next.nodes = (patch.nodes as any[]).map((node) => ensureLayout(node));
+        }
+        return syncSection(next);
+      });
       return { ...state, sections, dirty: true };
     }),
 
@@ -103,27 +159,33 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
       if (idx < 0) return state;
 
       const deep = (o: any) => JSON.parse(JSON.stringify(o));
-      const clone = deep(state.sections[idx]);
+      const source = syncSection(state.sections[idx]);
+      const clone = deep(source);
       clone.id = `sec_${crypto.randomUUID().slice(0, 6)}`;
       clone.title = `${clone.title || 'Sección'} (copia)`;
 
       const ensure = state.ensureUniqueKey;
-      clone.children = (clone.children || []).map((n: any) => {
+      const nodes = (clone.nodes || clone.children || []).map((n: any) => {
         const c = deep(n);
         c.id = `fld_${crypto.randomUUID().slice(0, 6)}`;
-        if (c.key) c.key = ensure(c.key);
+        if (!isUiNode(c)) {
+          c.key = ensure(c.key || c.type);
+        }
         if (c.children)
-          c.children = c.children.map((nn: any) => {
+          c.children = (c.children || []).map((nn: any) => {
             const cc = deep(nn);
             cc.id = `fld_${crypto.randomUUID().slice(0, 6)}`;
-            if (cc.key) cc.key = ensure(cc.key);
-            return cc;
+            if (!isUiNode(cc)) {
+              cc.key = ensure(cc.key || cc.type);
+            }
+            return ensureLayout(cc);
           });
-        return c;
+        return ensureLayout(c);
       });
+      clone.nodes = nodes;
 
       const sections = [...state.sections];
-      sections.splice(idx + 1, 0, clone);
+      sections.splice(idx + 1, 0, syncSection(clone));
       return { ...state, sections, selected: { type: 'section', id: clone.id }, dirty: true };
     }),
 
@@ -132,10 +194,10 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
       const sections = (state.sections || []).filter((s: any) => s.id !== id);
       if (sections.length === 0) {
         const fallbackId = `sec_${crypto.randomUUID().slice(0, 6)}`;
-        sections.push({ id: fallbackId, title: 'Sección 1', children: [] });
+        sections.push(syncSection({ id: fallbackId, title: 'Sección 1', nodes: [], layout_mode: 'flow' } as SectionNode));
         return { ...state, sections, selected: { type: 'section', id: fallbackId }, dirty: true };
       }
-      return { ...state, sections, selected: null, dirty: true };
+      return { ...state, sections: sections.map((s) => syncSection(s)), selected: null, dirty: true };
     }),
 
   addField: (sectionId, typeOrNode) => {
@@ -143,28 +205,30 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
     const idx = sections.findIndex((s) => s.id === sectionId);
     if (idx < 0) return;
 
-    const node: FieldNode =
-      typeof typeOrNode === 'string' ? (createNode(typeOrNode) as any) : { ...(typeOrNode as any) };
+    const rawNode: FieldNode =
+      typeof typeOrNode === 'string' ? (createNode(typeOrNode) as any) : ensureLayout({ ...(typeOrNode as any) });
 
-    node.id = node.id ?? `fld_${crypto.randomUUID().slice(0, 6)}`;
-    if (node.kind !== 'ui') {
+    const id = rawNode.id ?? `fld_${crypto.randomUUID().slice(0, 6)}`;
+    const node = ensureLayout({ ...rawNode, id });
+    if (!isUiNode(node)) {
       node.key = get().ensureUniqueKey(node.key || node.type || 'campo');
     }
 
     const sec = sections[idx];
+    const nodes = [...(sec.nodes || sec.children || []), node];
     const next = [...sections];
-    next[idx] = { ...sec, children: [...(sec.children || []), node] };
+    next[idx] = syncSection({ ...sec, nodes });
 
-    set({ sections: next, selected: { type: 'field', id: node.id }, dirty: true });
+    set({ sections: next, selected: { type: 'field', id }, dirty: true });
 
-    return node.id;
+    return id;
   },
 
   _locateNode(id: string) {
     const sections = get().sections || [];
     for (let si = 0; si < sections.length; si++) {
       const s = sections[si];
-      const list = s.children || [];
+      const list = s.nodes || s.children || [];
       const fi = list.findIndex((n: any) => n.id === id);
       if (fi >= 0) return { si, fi, section: s, node: list[fi] };
       // soporte para grupos
@@ -186,7 +250,7 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
   findSectionIdByField: (fieldId: string) => {
     const secs = get().sections || [];
     for (const s of secs) {
-      if ((s.children || []).some((n: any) => n.id === fieldId)) return s.id;
+      if ((s.nodes || s.children || []).some((n: any) => n.id === fieldId)) return s.id;
     }
     return null;
   },
@@ -207,20 +271,20 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
       const hit = (get() as any)._locateNode(id);
       if (!hit) return state;
       const sections = [...state.sections];
+      const section = sections[hit.si];
+      const nodes = [...(section.nodes || section.children || [])];
 
       if (hit.groupIndex != null) {
-        const grp = { ...sections[hit.si].children[hit.groupIndex] } as any;
+        const grp = { ...(nodes[hit.groupIndex] || {}) } as any;
         const inner = [...(grp.children || [])];
         inner[hit.innerIndex] = { ...inner[hit.innerIndex], ...patch };
         grp.children = inner;
-        const out = [...(sections[hit.si].children || [])];
-        out[hit.groupIndex] = grp;
-        sections[hit.si] = { ...sections[hit.si], children: out };
+        nodes[hit.groupIndex] = grp;
       } else {
-        const list = [...(sections[hit.si].children || [])];
-        list[hit.fi] = { ...list[hit.fi], ...patch };
-        sections[hit.si] = { ...sections[hit.si], children: list };
+        nodes[hit.fi] = { ...nodes[hit.fi], ...patch };
       }
+
+      sections[hit.si] = syncSection({ ...section, nodes });
       return { ...state, sections, dirty: true };
     }),
 
@@ -229,19 +293,17 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
       const hit = (get() as any)._locateNode(id);
       if (!hit) return state;
       const sections = [...state.sections];
+      const section = sections[hit.si];
+      const nodes = [...(section.nodes || section.children || [])];
 
       if (hit.groupIndex != null) {
-        const grp = { ...sections[hit.si].children[hit.groupIndex] } as any;
+        const grp = { ...(nodes[hit.groupIndex] || {}) } as any;
         grp.children = (grp.children || []).filter((_: any, i: number) => i !== hit.innerIndex);
-        const out = [...(sections[hit.si].children || [])];
-        out[hit.groupIndex] = grp;
-        sections[hit.si] = { ...sections[hit.si], children: out };
+        nodes[hit.groupIndex] = grp;
       } else {
-        sections[hit.si] = {
-          ...sections[hit.si],
-          children: (sections[hit.si].children || []).filter((_: any, i: number) => i !== hit.fi),
-        };
+        nodes.splice(hit.fi, 1);
       }
+      sections[hit.si] = syncSection({ ...section, nodes });
       return { ...state, sections, selected: null, dirty: true };
     }),
 
@@ -251,25 +313,27 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
       if (!hit) return state;
       const sections = [...state.sections];
       const clone = (obj: any) => JSON.parse(JSON.stringify(obj));
-      const node = clone(hit.node);
-      node.id = `fld_${crypto.randomUUID().slice(0, 6)}`;
-      if (node.kind !== 'ui') {
-        node.key = state.ensureUniqueKey(node.key || node.type);
+      const rawNode = clone(hit.node);
+      rawNode.id = `fld_${crypto.randomUUID().slice(0, 6)}`;
+      if (!isUiNode(rawNode)) {
+        rawNode.key = state.ensureUniqueKey(rawNode.key || rawNode.type);
       }
+      const node = ensureLayout(rawNode);
+
+      const section = sections[hit.si];
+      const nodes = [...(section.nodes || section.children || [])];
 
       if (hit.groupIndex != null) {
-        const grp = { ...sections[hit.si].children[hit.groupIndex] } as any;
+        const grp = { ...(nodes[hit.groupIndex] || {}) } as any;
         const inner = [...(grp.children || [])];
         inner.splice(hit.innerIndex + 1, 0, node);
         grp.children = inner;
-        const out = [...(sections[hit.si].children || [])];
-        out[hit.groupIndex] = grp;
-        sections[hit.si] = { ...sections[hit.si], children: out };
+        nodes[hit.groupIndex] = grp;
       } else {
-        const list = [...(sections[hit.si].children || [])];
-        list.splice(hit.fi + 1, 0, node);
-        sections[hit.si] = { ...sections[hit.si], children: list };
+        nodes.splice(hit.fi + 1, 0, node);
       }
+
+      sections[hit.si] = syncSection({ ...section, nodes });
       return { ...state, sections, selected: { type: 'field', id: node.id }, dirty: true };
     }),
 
@@ -288,11 +352,12 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
         fromIdx = -1,
         node: any = null;
       state.sections.forEach((s: any, si: number) => {
-        const idx = (s.children || []).findIndex((n: any) => n.id === activeId);
+        const list = s.nodes || s.children || [];
+        const idx = list.findIndex((n: any) => n.id === activeId);
         if (idx >= 0) {
           fromSi = si;
           fromIdx = idx;
-          node = s.children[idx];
+          node = list[idx];
         }
       });
       if (fromSi < 0 || !node) return state;
@@ -303,23 +368,27 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
         destSi = state.sections.findIndex((s: any) => s.id === toSectionId);
         if (destSi < 0) destSi = fromSi;
       } else if (overId) {
-        const hit = state.sections.findIndex((s: any) => (s.children || []).some((n: any) => n.id === overId));
+        const hit = state.sections.findIndex((s: any) => (s.nodes || s.children || []).some((n: any) => n.id === overId));
         if (hit >= 0) destSi = hit;
       }
 
-      const sections = state.sections.map((s: any) => ({ ...s, children: [...(s.children || [])] }));
-
-      // quitar del origen
-      const [removed] = sections[fromSi].children.splice(fromIdx, 1);
+      const sections = state.sections.map((s: any) => syncSection(s));
+      const fromSection = sections[fromSi];
+      const fromNodes = [...(fromSection.nodes || [])];
+      const [removed] = fromNodes.splice(fromIdx, 1);
+      sections[fromSi] = syncSection({ ...fromSection, nodes: fromNodes });
 
       // decidir índice destino (por defecto al final)
-      let destIndex = sections[destSi].children.length;
+      const destSection = sections[destSi];
+      const destNodes = [...(destSection.nodes || [])];
+      let destIndex = destNodes.length;
       if (overId) {
-        const idxOver = sections[destSi].children.findIndex((n: any) => n.id === overId);
+        const idxOver = destNodes.findIndex((n: any) => n.id === overId);
         if (idxOver >= 0) destIndex = idxOver; // insertar antes de "over"
       }
 
-      sections[destSi].children.splice(destIndex, 0, removed);
+      destNodes.splice(destIndex, 0, removed);
+      sections[destSi] = syncSection({ ...destSection, nodes: destNodes });
 
       return { ...state, sections, selected: { type: 'field', id: removed.id }, dirty: true };
     }),
@@ -338,7 +407,7 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
 
     sections.forEach((sec, i) => {
       const path = [`Sección ${i + 1}`];
-      const children = sec.children || [];
+      const children = sec.nodes || sec.children || [];
       const dataChildren = children.filter((n: any) => n.kind !== 'ui');
 
       if (dataChildren.length === 0) {
@@ -390,13 +459,13 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
         if (n.type === 'group') return walk(n.children || []);
         if (n.key && (t === '*' || n.type === t)) keys.push(n.key);
       });
-    walk(get().sections || []);
+    (get().sections || []).forEach((s: any) => walk(s.nodes || s.children || []));
     return keys;
   },
 
   ensureUniqueKey: (base) => {
     const keys = new Set<string>();
-    (get().sections || []).forEach((s: any) => (s.children || []).forEach((n: any) => n.key && keys.add(n.key)));
+    (get().sections || []).forEach((s: any) => (s.nodes || s.children || []).forEach((n: any) => n.key && keys.add(n.key)));
     let k = base;
     let c = 2;
     while (keys.has(k)) k = `${base}_${c++}`;
@@ -406,21 +475,28 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
   setDirty: (d) => set({ dirty: d }),
 
   setTemplate: (tpl) =>
-    set(() => ({
-      plantillaId: tpl?.id ?? null,
-      nombre: tpl?.nombre ?? '',
-      version: tpl?.version ?? 1,
-      descripcion: tpl?.descripcion ?? null,
-      sections: tpl?.schema?.nodes ?? tpl?.nodes ?? [],
-      selected: null,
-      dirty: false,
-    })),
+    set(() => {
+      const rawSections =
+        tpl?.schema?.sections ?? tpl?.schema?.nodes ?? tpl?.sections ?? tpl?.nodes ?? [];
+      const sections = Array.isArray(rawSections)
+        ? rawSections.map((sec: any) => normalizeSection(sec))
+        : [];
+      return {
+        plantillaId: tpl?.id ?? null,
+        nombre: tpl?.nombre ?? '',
+        version: tpl?.version ?? 1,
+        descripcion: tpl?.descripcion ?? null,
+        sections,
+        selected: null,
+        dirty: false,
+      };
+    }),
 
   setNombre: (n) => set({ nombre: n, dirty: true }),
   resetDirty: () => set({ dirty: false }),
 
   buildSchema: () => {
-    const nodes = get().sections || [];
-    return { id: get().plantillaId || undefined, name: get().nombre, version: get().version, nodes };
+    const sections = (get().sections || []).map((sec) => syncSection(sec));
+    return { id: get().plantillaId || undefined, name: get().nombre, version: get().version, nodes: sections };
   },
 }));


### PR DESCRIPTION
## Summary
- add react-grid-layout based designer for sections with grid layout mode
- persist layout metadata on builder nodes and expose grid rendering in legajo view
- ensure template serialization and builder store normalize UI nodes with layout defaults

## Testing
- npm run lint *(fails: interactive Next.js ESLint setup prompt)*
- npm run test *(fails: vitest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c8377e5b1c832da39c7285aafcede1