### PR TITLE
Implement legajos listing and creation flow

### DIFF
--- a/backend/legajos/tests/test_list_legajos.py
+++ b/backend/legajos/tests/test_list_legajos.py
@@ -1,0 +1,59 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from plantillas.models import Plantilla
+from legajos.serializers import LegajoSerializer
+from legajos.viewsets import LegajoViewSet
+
+
+@pytest.mark.django_db
+def test_list_filters_by_plantilla_and_search():
+    plantilla_a = Plantilla.objects.create(nombre="A", schema={"nodes": []})
+    plantilla_b = Plantilla.objects.create(nombre="B", schema={"nodes": []})
+
+    serializer = LegajoSerializer(
+        data={
+            "plantilla_id": str(plantilla_a.id),
+            "data": {"ciudadano": {"apellido": "Perez", "nombre": "Juan"}},
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    legajo_match = serializer.save()
+
+    serializer = LegajoSerializer(
+        data={
+            "plantilla_id": str(plantilla_a.id),
+            "data": {"ciudadano": {"apellido": "Gomez", "nombre": "Ana"}},
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    serializer.save()
+
+    serializer = LegajoSerializer(
+        data={
+            "plantilla_id": str(plantilla_b.id),
+            "data": {"ciudadano": {"apellido": "Perez", "nombre": "Maria"}},
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    serializer.save()
+
+    factory = APIRequestFactory()
+    request = factory.get(
+        f"/legajos/?plantilla_id={plantilla_a.id}&search=perez"
+    )
+    user_model = get_user_model()
+    user = user_model.objects.create_user(username="user", password="pass")
+    force_authenticate(request, user=user)
+
+    response = LegajoViewSet.as_view({"get": "list"})(request)
+    assert response.status_code == 200
+    assert response.data["count"] == 1
+    assert len(response.data["results"]) == 1
+
+    result = response.data["results"][0]
+    assert result["id"] == str(legajo_match.id)
+    assert result["plantilla_id"] == str(plantilla_a.id)
+    assert result["display"].startswith("Perez")
+    assert result["estado"] == "ACTIVO"

--- a/backend/legajos/tests/test_serializer.py
+++ b/backend/legajos/tests/test_serializer.py
@@ -11,7 +11,7 @@ def test_hidden_field_removed(db):
             ]}
         ]}
     )
-    serializer = LegajoSerializer(data={"plantilla": str(plantilla.id), "data": {"a": "1", "b": "2"}})
+    serializer = LegajoSerializer(data={"plantilla_id": str(plantilla.id), "data": {"a": "1", "b": "2"}})
     assert serializer.is_valid(), serializer.errors
     legajo = serializer.save()
     assert "b" not in legajo.data

--- a/backend/legajos/viewsets.py
+++ b/backend/legajos/viewsets.py
@@ -1,15 +1,64 @@
+import json
 from rest_framework import viewsets, response
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.pagination import PageNumberPagination
 from .models import Legajo
 from .serializers import LegajoSerializer
 from .services import LegajoMetaService
 
 
+class LegajoPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
 class LegajoViewSet(viewsets.ModelViewSet):
-    queryset = Legajo.objects.all()
+    queryset = Legajo.objects.select_related("plantilla").all()
     serializer_class = LegajoSerializer
     permission_classes = [IsAuthenticated]
     http_method_names = ["get", "post"]
+    pagination_class = LegajoPagination
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        plantilla_id = self.request.query_params.get("plantilla_id")
+        if plantilla_id:
+            qs = qs.filter(plantilla_id=plantilla_id)
+        return qs
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        search = (request.query_params.get("search") or "").strip()
+        if search:
+            serializer = self.get_serializer()
+            term = search.lower()
+
+            def matches(obj: Legajo) -> bool:
+                parts = []
+                try:
+                    display = serializer.get_display(obj) or ""
+                except Exception:
+                    display = ""
+                parts.append(display)
+                for source in (obj.grid_values, obj.data):
+                    if isinstance(source, dict):
+                        parts.append(json.dumps(source, ensure_ascii=False))
+                    elif isinstance(source, list):
+                        parts.append(json.dumps(source, ensure_ascii=False))
+                haystack = " ".join(parts).lower()
+                return term in haystack
+
+            queryset = [obj for obj in queryset if matches(obj)]
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return response.Response(serializer.data)
 
     def retrieve(self, request, *args, **kwargs):
         inst = self.get_object()

--- a/frontend/src/app/legajos/nuevo/_ListView.tsx
+++ b/frontend/src/app/legajos/nuevo/_ListView.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+
+type ListResponse = {
+  results: Array<Record<string, any>>;
+  next: string | null;
+  previous: string | null;
+  count: number;
+};
+
+async function fetchLegajos({
+  formId,
+  page = 1,
+  search = "",
+}: {
+  formId: string;
+  page?: number;
+  search?: string;
+}) {
+  const base =
+    API_BASE ||
+    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
+  if (!base) {
+    throw new Error("No se configuró la URL de la API");
+  }
+  const url = new URL(`/api/legajos`, base);
+  url.searchParams.set("plantilla_id", formId);
+  url.searchParams.set("page", String(page));
+  if (search) {
+    url.searchParams.set("search", search);
+  }
+  const res = await fetch(url.toString(), { credentials: "include" });
+  if (!res.ok) {
+    throw new Error("No se pudo cargar la lista de legajos");
+  }
+  return (await res.json()) as ListResponse;
+}
+
+function fmtDate(value?: string) {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return "—";
+  }
+}
+
+function guessDisplay(row: any) {
+  if (row?.display) return row.display;
+  const data = row?.data || {};
+  const containers = [data, data.ciudadano, data.persona, data.titular];
+  for (const item of containers) {
+    if (item && typeof item === "object") {
+      const apellido = item.apellido || item.last_name || item.apellidos;
+      const nombre = item.nombre || item.first_name || item.nombres;
+      if (apellido && nombre) return `${apellido}, ${nombre}`;
+      if (nombre) return nombre;
+      if (apellido) return apellido;
+    }
+  }
+  return row?.id || "—";
+}
+
+export default function ListView({ formId }: { formId: string }) {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    setPage(1);
+    setSearch("");
+  }, [formId]);
+
+  const { data, error, isLoading, isFetching } = useQuery({
+    queryKey: ["legajos", formId, page, search],
+    queryFn: () => fetchLegajos({ formId, page, search }),
+    keepPreviousData: true,
+  });
+
+  const rows = useMemo(() => data?.results ?? [], [data?.results]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => {
+            setPage(1);
+            setSearch(event.target.value);
+          }}
+          placeholder="Buscar…"
+          className="h-10 w-72 rounded-md border border-slate-200 px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400"
+        />
+        {isFetching && !isLoading && (
+          <span className="text-xs text-slate-500">Actualizando…</span>
+        )}
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border bg-white shadow-sm">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="px-4 py-2">Nombre</th>
+              <th className="px-4 py-2">Estado</th>
+              <th className="px-4 py-2">Creado</th>
+              <th className="px-4 py-2">Actualizado</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td className="px-4 py-6" colSpan={4}>
+                  Cargando…
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td className="px-4 py-6 text-red-600" colSpan={4}>
+                  Error al cargar la lista.
+                </td>
+              </tr>
+            ) : rows.length === 0 ? (
+              <tr>
+                <td className="px-4 py-6" colSpan={4}>
+                  Sin registros todavía.
+                </td>
+              </tr>
+            ) : (
+              rows.map((row: any) => (
+                <tr key={row.id} className="border-t">
+                  <td className="px-4 py-2 font-medium text-slate-700">{guessDisplay(row)}</td>
+                  <td className="px-4 py-2 text-slate-600">{row.estado || "—"}</td>
+                  <td className="px-4 py-2 text-slate-600">{fmtDate(row.created_at)}</td>
+                  <td className="px-4 py-2 text-slate-600">{fmtDate(row.updated_at)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-slate-600">
+        <button
+          type="button"
+          className="rounded-md border px-3 py-2 shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={() => setPage((current) => Math.max(1, current - 1))}
+          disabled={!data?.previous}
+        >
+          Anterior
+        </button>
+        <div className="text-xs text-slate-500">
+          Página {page} {data?.count ? `de ${Math.max(1, Math.ceil(data.count / 10))}` : ""}
+        </div>
+        <button
+          type="button"
+          className="rounded-md border px-3 py-2 shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={() => setPage((current) => current + 1)}
+          disabled={!data?.next}
+        >
+          Siguiente
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/legajos/nuevo/crear/_CreateView.tsx
+++ b/frontend/src/app/legajos/nuevo/crear/_CreateView.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import DynamicForm from "@/components/form/runtime/DynamicForm";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+
+async function fetchPlantilla(id: string) {
+  const base =
+    API_BASE ||
+    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
+  if (!base) {
+    throw new Error("No se pudo resolver la URL de la API");
+  }
+  const res = await fetch(new URL(`/api/plantillas/${id}`, base).toString(), {
+    credentials: "include",
+  });
+  if (!res.ok) {
+    throw new Error("No se pudo cargar la plantilla");
+  }
+  return res.json();
+}
+
+async function createLegajo(payload: { plantilla_id: string; data: any }) {
+  const base =
+    API_BASE ||
+    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
+  if (!base) {
+    throw new Error("No se pudo resolver la URL de la API");
+  }
+  const res = await fetch(new URL(`/api/legajos`, base).toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || "No se pudo crear el legajo");
+  }
+  return res.json();
+}
+
+export default function CreateView({ formId }: { formId: string }) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["plantilla", formId],
+    queryFn: () => fetchPlantilla(formId),
+  });
+
+  const mutation = useMutation({
+    mutationFn: createLegajo,
+  });
+
+  if (isLoading) {
+    return <div>Cargando plantilla…</div>;
+  }
+
+  if (error || !data) {
+    return <div>Error al cargar la plantilla.</div>;
+  }
+
+  const schema = data?.schema ?? { nodes: [] };
+
+  return (
+    <DynamicForm
+      schema={schema}
+      onSubmit={async (values) => {
+        if (mutation.isPending) return;
+        try {
+          await mutation.mutateAsync({ plantilla_id: formId, data: values });
+          await queryClient.invalidateQueries({ queryKey: ["legajos", formId] });
+          router.push(`/legajos/nuevo?formId=${formId}`);
+        } catch (e) {
+          console.error(e);
+          const message = e instanceof Error ? e.message : "No se pudo crear el legajo";
+          alert(message);
+        }
+      }}
+    />
+  );
+}

--- a/frontend/src/app/legajos/nuevo/crear/page.tsx
+++ b/frontend/src/app/legajos/nuevo/crear/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from "react";
+import CreateView from "./_CreateView";
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: { formId?: string };
+}) {
+  const formId = searchParams?.formId;
+  if (!formId) {
+    return (
+      <div className="p-6">
+        Falta <code>formId</code>.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <h1 className="text-2xl font-semibold">Nuevo legajo</h1>
+      <Suspense fallback={<div className="rounded-md border p-4">Cargando…</div>}>
+        <CreateView formId={formId} />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/app/legajos/nuevo/page.tsx
+++ b/frontend/src/app/legajos/nuevo/page.tsx
@@ -1,68 +1,59 @@
-'use client';
+import Link from "next/link";
+import { Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import ListView from "./_ListView";
 
-import { useSearchParams, useRouter } from 'next/navigation';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { PlantillasService } from '@/lib/services/plantillas';
-import { LegajosService } from '@/lib/services/legajos';
-import DynamicForm from '@/components/form/runtime/DynamicForm';
+async function fetchPlantilla(formId: string) {
+  const base = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+  if (!base) return null;
+  try {
+    const res = await fetch(`${base}/api/plantillas/${formId}`, {
+      cache: "no-store",
+      credentials: "include",
+    });
+    if (!res.ok) {
+      return null;
+    }
+    return res.json();
+  } catch (error) {
+    console.error("fetchPlantilla", error);
+    return null;
+  }
+}
 
-export default function NuevoLegajoPage() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const q = useQueryClient();
-
-  const formId = params.get('formId') || '';
-
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['plantilla', formId],
-    enabled: !!formId,
-    queryFn: () => PlantillasService.fetchPlantilla(formId),
-  });
-
-  const mut = useMutation({
-    mutationFn: (payload: any) => LegajosService.create(payload),
-    onSuccess: () => {
-      alert('Legajo creado');
-      q.invalidateQueries({ queryKey: ['legajos', 'list'] });
-      router.push('/legajos'); // TODO: Navegar al detalle o listado real
-    },
-    onError: (e: any) => alert(e?.message || 'Error al crear el legajo'),
-  });
-
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: { formId?: string };
+}) {
+  const formId = searchParams?.formId;
   if (!formId) {
     return (
       <div className="p-6">
-        Falta <code>formId</code> en la URL.
+        Falta <code>formId</code>.
       </div>
     );
   }
 
-  if (isLoading) return <div className="p-6">Cargando…</div>;
-  if (error || !data) return <div className="p-6">Error cargando la plantilla.</div>;
-
-  // Normalizar schema (acepta .schema.nodes o .nodes)
-  const template =
-    data?.schema?.id
-      ? data.schema
-      : {
-          id: data?.id,
-          name: data?.nombre,
-          nodes: data?.schema?.nodes ?? data?.nodes ?? [],
-        };
+  const plantilla = await fetchPlantilla(formId);
+  const nombre = plantilla?.nombre ?? formId;
 
   return (
-    <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Nuevo legajo — {data?.nombre ?? 'Plantilla'}</h1>
-
-      <DynamicForm
-        template={template}
-        onSubmit={(values) =>
-          mut.mutate({
-            formulario: data.id, // adapta a tu backend si el campo se llama distinto
-            data: values,
-          })
-        }
-      />
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-semibold">Legajos — {nombre}</h1>
+        <Button asChild>
+          <Link href={`/legajos/nuevo/crear?formId=${formId}`}>Crear</Link>
+        </Button>
+      </div>
+      {!plantilla && (
+        <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+          No se pudo cargar la plantilla. Verificá que exista y que tengas permisos.
+        </div>
+      )}
+      <Suspense fallback={<div className="rounded-md border p-4">Cargando…</div>}>
+        <ListView formId={formId} />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/lib/services/legajos.ts
+++ b/frontend/src/lib/services/legajos.ts
@@ -1,17 +1,18 @@
 import { http } from './http';
 
 export const LegajosService = {
-  create: (payload: { formulario: string; data: any }) =>
+  create: (payload: { plantilla_id: string; data: any }) =>
     http('/legajos/', { method: 'POST', body: JSON.stringify(payload) }),
-  // (Opcional) listar y detalle:
   list: (
-    params: { formId?: string; page?: number; page_size?: number } = {}
+    params: { formId?: string; page?: number; page_size?: number; search?: string } = {}
   ) => {
     const q = new URLSearchParams();
-    if (params.formId) q.set('formulario', params.formId);
+    if (params.formId) q.set('plantilla_id', params.formId);
     if (params.page) q.set('page', String(params.page));
     if (params.page_size) q.set('page_size', String(params.page_size));
-    return http(`/legajos/${q.toString() ? `?${q}` : ''}`);
+    if (params.search) q.set('search', params.search);
+    const qs = q.toString();
+    return http(`/legajos/${qs ? `?${qs}` : ''}`);
   },
   get: (id: string) => http(`/legajos/${id}/`),
 };


### PR DESCRIPTION
## Summary
- expose legajo serializer fields for plantilla_id, computed display and estado, and add pagination and search support to the viewset
- add coverage for listing legajos filtered by plantilla, ensuring display and estado values appear in the API response
- build the legajos creation/listing UI with TanStack Query, server-driven routing, and updated client helpers

## Testing
- pytest *(fails: Django dependency missing because packages cannot be downloaded in the execution environment)*
- npm run lint *(not run: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c838b4339c832d82df7fcc08f16d78