### PR TITLE
Fix frontend API proxy and auth handling

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=http://localhost:8000/api
+API_URL_INTERNAL=http://backend:8000

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=http://localhost:8000/api
+API_URL_INTERNAL=http://backend:8000

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,16 @@
 /** @type {import('next').NextConfig} */
+const API_INTERNAL = process.env.API_URL_INTERNAL || "http://backend:8000";
+
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${API_INTERNAL.replace(/\/$/, "")}/api/:path*`,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/frontend/src/app/legajos/[id]/page.tsx
+++ b/frontend/src/app/legajos/[id]/page.tsx
@@ -1,10 +1,8 @@
-import SectionRenderer from '@/components/legajo/SectionRenderer';
+import SectionRenderer from "@/components/legajo/SectionRenderer";
+import { getJSON } from "@/lib/api";
 
 export default async function LegajoDetallePage({ params }: { params: { id: string } }) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/legajos/${params.id}`, {
-    cache: 'no-store',
-  });
-  const { data, schema, meta } = await res.json();
+  const { data, schema, meta } = await getJSON(`/api/legajos/${params.id}`, { cache: "no-store" });
   const sections = schema?.nodes || schema?.sections || [];
 
   return (

--- a/frontend/src/app/legajos/nuevo/_ListView.tsx
+++ b/frontend/src/app/legajos/nuevo/_ListView.tsx
@@ -2,8 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+import { getJSON } from "@/lib/api";
 
 type ListResponse = {
   results: Array<Record<string, any>>;
@@ -21,23 +20,18 @@ async function fetchLegajos({
   page?: number;
   search?: string;
 }) {
-  const base =
-    API_BASE ||
-    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
-  if (!base) {
-    throw new Error("No se configuró la URL de la API");
+  if (typeof window === "undefined") {
+    throw new Error("fetchLegajos solo está disponible en el cliente");
   }
-  const url = new URL(`/api/legajos`, base);
+
+  const url = new URL(`/api/legajos`, window.location.origin);
   url.searchParams.set("plantilla_id", formId);
   url.searchParams.set("page", String(page));
   if (search) {
     url.searchParams.set("search", search);
   }
-  const res = await fetch(url.toString(), { credentials: "include" });
-  if (!res.ok) {
-    throw new Error("No se pudo cargar la lista de legajos");
-  }
-  return (await res.json()) as ListResponse;
+
+  return getJSON<ListResponse>(`${url.pathname}${url.search}`);
 }
 
 function fmtDate(value?: string) {

--- a/frontend/src/app/legajos/nuevo/crear/_CreateView.tsx
+++ b/frontend/src/app/legajos/nuevo/crear/_CreateView.tsx
@@ -3,45 +3,14 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import DynamicForm from "@/components/form/runtime/DynamicForm";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+import { getJSON, postJSON } from "@/lib/api";
 
 async function fetchPlantilla(id: string) {
-  const base =
-    API_BASE ||
-    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
-  if (!base) {
-    throw new Error("No se pudo resolver la URL de la API");
-  }
-  const res = await fetch(new URL(`/api/plantillas/${id}`, base).toString(), {
-    credentials: "include",
-  });
-  if (!res.ok) {
-    throw new Error("No se pudo cargar la plantilla");
-  }
-  return res.json();
+  return getJSON(`/api/plantillas/${id}`);
 }
 
 async function createLegajo(payload: { plantilla_id: string; data: any }) {
-  const base =
-    API_BASE ||
-    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
-  if (!base) {
-    throw new Error("No se pudo resolver la URL de la API");
-  }
-  const res = await fetch(new URL(`/api/legajos`, base).toString(), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    credentials: "include",
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || "No se pudo crear el legajo");
-  }
-  return res.json();
+  return postJSON(`/api/legajos`, payload);
 }
 
 export default function CreateView({ formId }: { formId: string }) {

--- a/frontend/src/app/legajos/nuevo/page.tsx
+++ b/frontend/src/app/legajos/nuevo/page.tsx
@@ -1,20 +1,12 @@
 import Link from "next/link";
 import { Suspense } from "react";
 import { Button } from "@/components/ui/button";
+import { getJSON } from "@/lib/api";
 import ListView from "./_ListView";
 
 async function fetchPlantilla(formId: string) {
-  const base = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
-  if (!base) return null;
   try {
-    const res = await fetch(`${base}/api/plantillas/${formId}`, {
-      cache: "no-store",
-      credentials: "include",
-    });
-    if (!res.ok) {
-      return null;
-    }
-    return res.json();
+    return await getJSON(`/api/plantillas/${formId}`, { cache: "no-store" });
   } catch (error) {
     console.error("fetchPlantilla", error);
     return null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,86 @@
-export async function fetcher<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-  });
+const ACCESS_TOKEN_KEY = "access_token";
+const REFRESH_TOKEN_KEY = "refresh_token";
+
+const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
+
+const isServer = typeof window === "undefined";
+
+export function resolveApiUrl(path: string): string {
+  if (ABSOLUTE_URL_REGEX.test(path)) {
+    return path;
+  }
+
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+
+  if (typeof window === "undefined") {
+    const base = (process.env.API_URL_INTERNAL || "http://backend:8000").replace(/\/$/, "");
+    return `${base}${normalized}`;
+  }
+
+  return normalized;
+}
+
+function withAuth(init: RequestInit = {}): RequestInit {
+  const headers = new Headers(init.headers ?? {});
+
+  if (!isServer) {
+    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+    if (token && !headers.has("Authorization")) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+  }
+
+  const requestInit: RequestInit = {
+    ...init,
+    headers,
+  };
+
+  if (!requestInit.credentials) {
+    requestInit.credentials = "include";
+  }
+
+  return requestInit;
+}
+
+export async function api(path: string, init?: RequestInit) {
+  const response = await fetch(resolveApiUrl(path), withAuth(init));
+
+  if (response.status === 401) {
+    if (!isServer) {
+      localStorage.removeItem(ACCESS_TOKEN_KEY);
+      localStorage.removeItem(REFRESH_TOKEN_KEY);
+      window.location.href = "/login";
+    }
+    throw new Error("Unauthorized");
+  }
+
+  return response;
+}
+
+export async function getJSON<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+  const res = await api(path, init);
   if (!res.ok) {
-    throw new Error('API error');
+    throw new Error(`HTTP ${res.status}`);
   }
   return res.json() as Promise<T>;
 }
 
-export const api = {
-  get: (url: string) => fetcher(url),
-  post: (url: string, data: any) => fetcher(url, { method: 'POST', body: JSON.stringify(data) }),
-  put: (url: string, data: any) => fetcher(url, { method: 'PUT', body: JSON.stringify(data) }),
-};
+export async function postJSON<T = unknown>(path: string, body: unknown, init?: RequestInit): Promise<T> {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const res = await api(path, {
+    ...init,
+    method: init?.method ?? "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+
+  return res.json() as Promise<T>;
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,11 +1,14 @@
 "use client";
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-
 type Tokens = { access: string; refresh: string };
 
 const LS_ACCESS = "access_token";
 const LS_REFRESH = "refresh_token";
+
+function resolvePath(path: string): string {
+  if (/^https?:\/\//i.test(path)) return path;
+  return path.startsWith("/") ? path : `/${path}`;
+}
 
 export function getTokens(): Tokens | null {
   const access = typeof window !== "undefined" ? localStorage.getItem(LS_ACCESS) : null;
@@ -26,61 +29,86 @@ export function clearTokens() {
 async function refreshAccessToken(): Promise<string | null> {
   const tokens = getTokens();
   if (!tokens) return null;
-  const res = await fetch(`${API}/api/token/refresh/`, {
+
+  const res = await fetch(resolvePath("/api/token/refresh/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ refresh: tokens.refresh }),
+    credentials: "include",
   });
+
   if (!res.ok) return null;
+
   const data = await res.json();
   const access = data.access as string;
   setTokens({ access, refresh: tokens.refresh });
   return access;
 }
 
-export async function authFetch(input: RequestInfo, init: RequestInit = {}): Promise<Response> {
-  let access = getTokens()?.access;
-  const headers = new Headers(init.headers);
-  if (access) headers.set("Authorization", `Bearer ${access}`);
-  headers.set("Content-Type", headers.get("Content-Type") || "application/json");
+export async function authFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+  const target =
+    typeof input === "string"
+      ? resolvePath(input)
+      : input instanceof URL
+        ? resolvePath(input.toString())
+        : input;
 
-  let res = await fetch(input, { ...init, headers });
+  let access = getTokens()?.access;
+  const headers = new Headers(init.headers ?? {});
+
+  if (access && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${access}`);
+  }
+
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const requestInit: RequestInit = {
+    ...init,
+    headers,
+    credentials: init.credentials ?? "include",
+  };
+
+  let res = await fetch(target, requestInit);
   if (res.status !== 401) return res;
 
-  // reintento con refresh
   const newAccess = await refreshAccessToken();
   if (!newAccess) return res;
+
   headers.set("Authorization", `Bearer ${newAccess}`);
-  res = await fetch(input, { ...init, headers });
+  res = await fetch(target, requestInit);
   return res;
 }
 
 export async function login(identifier: string, password: string, remember = true) {
-  const body = { identifier, password, username: identifier }; // backend aceptará email/username
-  const res = await fetch(`${API}/api/token/`, {
+  const body = { identifier, password, username: identifier };
+  const res = await fetch(resolvePath("/api/token/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    credentials: "include",
   });
+
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.detail || "Credenciales inválidas");
   }
+
   const data = (await res.json()) as Tokens;
   setTokens(data);
+
   if (!remember) {
-    // opción simple: limpiar refresh al cerrar tab
     window.addEventListener("beforeunload", () => clearTokens());
   }
 }
 
 export async function me() {
-  const res = await authFetch(`${API}/api/auth/me/`, { method: "GET" });
+  const res = await authFetch("/api/auth/me/", { method: "GET" });
   if (!res.ok) throw new Error("No autenticado");
   return res.json();
 }
 
 export function logout() {
   clearTokens();
-  // Opcional: invalidate react-query aquí si lo usás
 }

--- a/frontend/src/lib/services/http.ts
+++ b/frontend/src/lib/services/http.ts
@@ -1,58 +1,70 @@
+import { resolveApiUrl } from "@/lib/api";
+
 export type HttpOptions = RequestInit & { timeoutMs?: number; auth?: boolean };
 
-const API_BASE = (process.env.NEXT_PUBLIC_API_BASE || '').replace(/\/$/, ''); // ej: http://localhost:8000/api
+const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
 
 export function buildUrl(path: string) {
-  const p = path.startsWith('/') ? path : `/${path}`;
-  // si NO hay base => usamos relativo (lo manejará el rewrite de Next)
-  return API_BASE ? `${API_BASE}${p}` : p;
+  if (ABSOLUTE_URL_REGEX.test(path)) {
+    return path;
+  }
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return resolveApiUrl(normalized);
 }
 
 function withTimeout<T>(p: Promise<T>, ms = 15000) {
   return new Promise<T>((resolve, reject) => {
     const id = setTimeout(() => reject(new Error(`Timeout ${ms}ms`)), ms);
-    p.then((v) => { clearTimeout(id); resolve(v); }, (e) => { clearTimeout(id); reject(e); });
+    p.then(
+      (v) => {
+        clearTimeout(id);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(id);
+        reject(e);
+      },
+    );
   });
 }
 
 export async function http(path: string, opts: HttpOptions = {}) {
   let url = buildUrl(path);
-  if (typeof window !== 'undefined' && url.includes('://backend:')) {
-    url = url.replace('://backend:', '://localhost:');
+  if (typeof window !== "undefined" && typeof url === "string" && url.includes("://backend:")) {
+    url = url.replace("://backend:", "://localhost:");
   }
 
-  const method = (opts.method || 'GET').toUpperCase();
-  if (method !== 'GET') {
-    const [base, qs] = url.split('?');
-    if (!base.endsWith('/')) url = `${base}/${qs ? `?${qs}` : ''}`;
+  const method = (opts.method || "GET").toUpperCase();
+  if (method !== "GET" && typeof url === "string") {
+    const [base, qs] = url.split("?");
+    if (!base.endsWith("/")) url = `${base}/${qs ? `?${qs}` : ""}`;
   }
 
   const headers: Record<string, string> = { ...(opts.headers as any) };
-  if (!(opts.body instanceof FormData) && !('Content-Type' in headers)) {
-    headers['Content-Type'] = 'application/json';
+  if (!(opts.body instanceof FormData) && !("Content-Type" in headers)) {
+    headers["Content-Type"] = "application/json";
   }
-  if (opts.auth !== false && typeof window !== 'undefined') {
-    const token = localStorage.getItem('access_token');
-    if (token) headers['Authorization'] = `Bearer ${token}`;
+  if (opts.auth !== false && typeof window !== "undefined") {
+    const token = localStorage.getItem("access_token");
+    if (token) headers["Authorization"] = `Bearer ${token}`;
   }
 
   const cfg: RequestInit = {
     ...opts,
     headers,
-    credentials: 'include',
+    credentials: opts.credentials ?? "include",
   };
 
-  // intento 1
   try {
-    console.info('[http]', opts.method || 'GET', url);
+    console.info("[http]", opts.method || "GET", url);
     const res = await withTimeout(fetch(url, cfg), opts.timeoutMs || 15000);
 
-    const ct = res.headers.get('content-type') || '';
+    const ct = res.headers.get("content-type") || "";
     const text = await res.text();
 
     if (!res.ok) {
-      if (ct.includes('text/html')) {
-        const snippet = (text || '').slice(0, 400);
+      if (ct.includes("text/html")) {
+        const snippet = (text || "").slice(0, 400);
         throw new Error(`HTTP ${res.status}. HTML: ${snippet}`);
       }
       try {
@@ -63,22 +75,21 @@ export async function http(path: string, opts: HttpOptions = {}) {
       }
     }
 
-    return ct.includes('application/json') ? (text ? JSON.parse(text) : {}) : (text as any);
+    return ct.includes("application/json") ? (text ? JSON.parse(text) : {}) : (text as any);
   } catch (e: any) {
-    console.error('[http failed]', e?.name || '', e?.message || e);
+    console.error("[http failed]", e?.name || "", e?.message || e);
 
-    // Fallback: si estás usando sin querer "http://backend:puerto", reintenta con "http://localhost:puerto"
-    if (typeof url === 'string' && url.includes('://backend:')) {
-      const fallback = url.replace('://backend:', '://localhost:');
+    if (typeof url === "string" && url.includes("://backend:")) {
+      const fallback = url.replace("://backend:", "://localhost:");
       try {
-        console.warn('[http retry]', fallback);
+        console.warn("[http retry]", fallback);
         const res = await withTimeout(fetch(fallback, cfg), opts.timeoutMs || 15000);
         if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-        const ct = res.headers.get('content-type') || '';
+        const ct = res.headers.get("content-type") || "";
         const text = await res.text();
-        return ct.includes('application/json') ? (text ? JSON.parse(text) : {}) : (text as any);
+        return ct.includes("application/json") ? (text ? JSON.parse(text) : {}) : (text as any);
       } catch (e2) {
-        console.error('[http retry failed]', e2);
+        console.error("[http retry failed]", e2);
         throw e2;
       }
     }


### PR DESCRIPTION
## Summary
- proxy `/api` requests from Next to the backend container via rewrites and internal env defaults
- add an authenticated API helper that forwards tokens, redirects on 401, and reuse it across legajo pages
- align auth utilities and the shared HTTP client with the new proxy-friendly, relative URL approach

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c83e916974832daf3ce5cb0cbae9b3