### PR TITLE
Fix API base URL handling for Docker environment

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,6 @@ DATABASE_HOST=mysql
 DATABASE_PORT=3306
 
 # Frontend / API
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=http://backend:8000
 FRONTEND_URL=http://localhost:3008
 NEXT_PUBLIC_API_BASE=http://backend:8000/api

--- a/frontend/src/app/legajos/[id]/page.tsx
+++ b/frontend/src/app/legajos/[id]/page.tsx
@@ -1,7 +1,12 @@
 import SectionRenderer from '@/components/legajo/SectionRenderer';
+import { getApiBaseUrl } from '@/lib/env';
 
 export default async function LegajoDetallePage({ params }: { params: { id: string } }) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/legajos/${params.id}`, {
+  const base = getApiBaseUrl();
+  if (!base) {
+    throw new Error('No se configuró la URL de la API');
+  }
+  const res = await fetch(`${base}/api/legajos/${params.id}`, {
     cache: 'no-store',
   });
   const { data, schema, meta } = await res.json();

--- a/frontend/src/app/legajos/nuevo/_ListView.tsx
+++ b/frontend/src/app/legajos/nuevo/_ListView.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+import { getApiBaseUrl } from "@/lib/env";
 
 type ListResponse = {
   results: Array<Record<string, any>>;
@@ -21,9 +21,7 @@ async function fetchLegajos({
   page?: number;
   search?: string;
 }) {
-  const base =
-    API_BASE ||
-    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
+  const base = getApiBaseUrl();
   if (!base) {
     throw new Error("No se configuró la URL de la API");
   }

--- a/frontend/src/app/legajos/nuevo/crear/_CreateView.tsx
+++ b/frontend/src/app/legajos/nuevo/crear/_CreateView.tsx
@@ -3,13 +3,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import DynamicForm from "@/components/form/runtime/DynamicForm";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+import { getApiBaseUrl } from "@/lib/env";
 
 async function fetchPlantilla(id: string) {
-  const base =
-    API_BASE ||
-    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
+  const base = getApiBaseUrl();
   if (!base) {
     throw new Error("No se pudo resolver la URL de la API");
   }
@@ -23,9 +20,7 @@ async function fetchPlantilla(id: string) {
 }
 
 async function createLegajo(payload: { plantilla_id: string; data: any }) {
-  const base =
-    API_BASE ||
-    (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
+  const base = getApiBaseUrl();
   if (!base) {
     throw new Error("No se pudo resolver la URL de la API");
   }

--- a/frontend/src/app/legajos/nuevo/page.tsx
+++ b/frontend/src/app/legajos/nuevo/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 import { Suspense } from "react";
 import { Button } from "@/components/ui/button";
+import { getApiBaseUrl } from "@/lib/env";
 import ListView from "./_ListView";
 
 async function fetchPlantilla(formId: string) {
-  const base = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+  const base = getApiBaseUrl();
   if (!base) return null;
   try {
     const res = await fetch(`${base}/api/plantillas/${formId}`, {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,11 @@
+import { getApiBaseUrl } from "@/lib/env";
+
 export async function fetcher<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
+  const base = getApiBaseUrl();
+  if (!base) {
+    throw new Error("No se configuró la URL de la API");
+  }
+  const res = await fetch(`${base}${url}`, {
     ...options,
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,6 +1,8 @@
 "use client";
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+import { getApiBaseUrl } from "@/lib/env";
+
+const API = getApiBaseUrl() || "http://localhost:8000";
 
 type Tokens = { access: string; refresh: string };
 

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,18 @@
+const RAW_API_URL = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "");
+
+function normalizeForBrowser(url: string) {
+  if (typeof window !== "undefined" && url.includes("://backend:")) {
+    return url.replace("://backend:", "://localhost:");
+  }
+  return url;
+}
+
+export function getApiBaseUrl() {
+  let base = RAW_API_URL;
+
+  if (!base && typeof window !== "undefined") {
+    base = window.location.origin.replace(/\/$/, "");
+  }
+
+  return normalizeForBrowser(base);
+}


### PR DESCRIPTION
## Summary
- update the default NEXT_PUBLIC_API_URL to point at the Docker backend service
- add a shared helper to resolve the API base URL for server and browser contexts
- refactor legajos pages and API utilities to use the helper so requests work in Docker

## Testing
- ⚠️ `npm run lint` *(fails: local Next.js dependency missing because npm ci hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c83c0806c8832d918c59f969fafa3f