### PR TITLE
Add token helpers and refresh logic for API client

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,4 @@
-
-const ACCESS_TOKEN_KEY = "access_token";
-const REFRESH_TOKEN_KEY = "refresh_token";
+import { clearStoredTokens, getAccessToken } from "@/lib/tokens";
 
 const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
 
@@ -61,7 +59,7 @@ function withAuth(init: RequestInit = {}): RequestInit {
   const headers = new Headers(init.headers ?? {});
 
   if (!isServer) {
-    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+    const token = getAccessToken();
     if (token && !headers.has("Authorization")) {
       headers.set("Authorization", `Bearer ${token}`);
     }
@@ -86,8 +84,7 @@ export async function api(path: string, init: RequestInit = {}) {
 
   if (response.status === 401) {
     if (!isServer) {
-      localStorage.removeItem(ACCESS_TOKEN_KEY);
-      localStorage.removeItem(REFRESH_TOKEN_KEY);
+      clearStoredTokens();
       window.location.href = "/login";
     }
     throw new Error("Unauthorized");

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,13 +1,7 @@
 "use client";
 
-
 import { buildApiUrl } from "@/lib/api";
-
-
-type Tokens = { access: string; refresh: string };
-
-const LS_ACCESS = "access_token";
-const LS_REFRESH = "refresh_token";
+import { Tokens, clearStoredTokens, getStoredTokens, storeTokens } from "@/lib/tokens";
 
 function resolvePath(path: string): string {
   if (/^https?:\/\//i.test(path)) return path;
@@ -15,19 +9,15 @@ function resolvePath(path: string): string {
 }
 
 export function getTokens(): Tokens | null {
-  const access = typeof window !== "undefined" ? localStorage.getItem(LS_ACCESS) : null;
-  const refresh = typeof window !== "undefined" ? localStorage.getItem(LS_REFRESH) : null;
-  return access && refresh ? { access, refresh } : null;
+  return getStoredTokens();
 }
 
 export function setTokens(t: Tokens) {
-  localStorage.setItem(LS_ACCESS, t.access);
-  localStorage.setItem(LS_REFRESH, t.refresh);
+  storeTokens(t);
 }
 
 export function clearTokens() {
-  localStorage.removeItem(LS_ACCESS);
-  localStorage.removeItem(LS_REFRESH);
+  clearStoredTokens();
 }
 
 async function refreshAccessToken(): Promise<string | null> {
@@ -35,7 +25,6 @@ async function refreshAccessToken(): Promise<string | null> {
   if (!tokens) return null;
 
   const res = await fetch(buildApiUrl("/api/token/refresh/", "POST"), {
-
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ refresh: tokens.refresh }),

--- a/frontend/src/lib/services/http.ts
+++ b/frontend/src/lib/services/http.ts
@@ -1,11 +1,15 @@
-
 import { buildApiUrl } from "@/lib/api";
+import {
+  clearStoredTokens,
+  getAccessToken,
+  getRefreshToken,
+  storeTokens,
+} from "@/lib/tokens";
 
 export type HttpOptions = RequestInit & { timeoutMs?: number; auth?: boolean };
 
 export function buildUrl(path: string, method = "GET") {
   return buildApiUrl(path, method);
-
 }
 
 function withTimeout<T>(p: Promise<T>, ms = 15000) {
@@ -24,72 +28,148 @@ function withTimeout<T>(p: Promise<T>, ms = 15000) {
   });
 }
 
-export async function http(path: string, opts: HttpOptions = {}) {
+async function refreshAccessToken(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  const refresh = getRefreshToken();
+  if (!refresh) return null;
 
-  const method = (opts.method || "GET").toUpperCase();
-  let url = buildUrl(path, method);
-  if (typeof window !== "undefined" && typeof url === "string" && url.includes("://backend:")) {
-    url = url.replace("://backend:", "://localhost:");
+  try {
+    const res = await fetch(buildApiUrl("/api/token/refresh/", "POST"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh }),
+      credentials: "include",
+    });
 
+    if (!res.ok) {
+      clearStoredTokens();
+      return null;
+    }
+
+    const data = await res.json().catch(() => null);
+    const access = data?.access;
+    if (typeof access === "string" && access) {
+      storeTokens({ access, refresh });
+      return access;
+    }
+  } catch (error) {
+    console.error("[http refresh failed]", (error as Error)?.message || error);
   }
 
-  const headers: Record<string, string> = { ...(opts.headers as any) };
-  if (!(opts.body instanceof FormData) && !("Content-Type" in headers)) {
-    headers["Content-Type"] = "application/json";
-  }
-  if (opts.auth !== false && typeof window !== "undefined") {
-    const token = localStorage.getItem("access_token");
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+  return null;
+}
+
+async function fetchWithAuthRetry(
+  url: string | URL,
+  init: RequestInit,
+  timeout: number,
+  shouldAuth: boolean,
+): Promise<Response> {
+  let res = await withTimeout(fetch(url, init), timeout);
+  if (res.status !== 401 || !shouldAuth || typeof window === "undefined") {
+    return res;
   }
 
-  const cfg: RequestInit = {
-    ...opts,
-    method,
+  const newAccess = await refreshAccessToken();
+  if (!newAccess) {
+    return res;
+  }
+
+  const headers = new Headers(init.headers as HeadersInit | undefined);
+  headers.set("Authorization", `Bearer ${newAccess}`);
+
+  const retryInit: RequestInit = {
+    ...init,
     headers,
-    credentials: opts.credentials ?? "include",
+  };
+
+  res = await withTimeout(fetch(url, retryInit), timeout);
+  return res;
+}
+
+async function parseResponse(res: Response) {
+  const ct = res.headers.get("content-type") || "";
+  const text = await res.text();
+
+  if (!res.ok) {
+    if (ct.includes("text/html")) {
+      const snippet = (text || "").slice(0, 400);
+      throw new Error(`HTTP ${res.status}. HTML: ${snippet}`);
+    }
+    try {
+      const json = text ? JSON.parse(text) : {};
+      throw new Error(json?.detail || json?.message || `HTTP ${res.status}`);
+    } catch {
+      throw new Error(text || `HTTP ${res.status}`);
+    }
+  }
+
+  if (ct.includes("application/json")) {
+    return text ? JSON.parse(text) : {};
+  }
+
+  return text as any;
+}
+
+export async function http(path: string, opts: HttpOptions = {}) {
+  const method = (opts.method || "GET").toUpperCase();
+  let target = buildUrl(path, method);
+
+  if (typeof window !== "undefined" && typeof target === "string" && target.includes("://backend:")) {
+    target = target.replace("://backend:", "://localhost:");
+  }
+
+  const { timeoutMs, auth, ...rest } = opts;
+  const timeout = timeoutMs ?? 15000;
+  const shouldAuth = auth !== false;
+
+  const buildHeaders = () => {
+    const headers = new Headers(rest.headers as HeadersInit | undefined);
+    if (!(rest.body instanceof FormData) && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    if (shouldAuth) {
+      const token = getAccessToken();
+      if (token) {
+        headers.set("Authorization", `Bearer ${token}`);
+      }
+    }
+    return headers;
+  };
+
+  const createInit = (): RequestInit => {
+    const headers = buildHeaders();
+    return {
+      ...rest,
+      method,
+      headers,
+      credentials: rest.credentials ?? "include",
+    };
+  };
+
+  const execute = async (url: string | URL) => {
+    const init = createInit();
+    const res = await fetchWithAuthRetry(url, init, timeout, shouldAuth);
+    return parseResponse(res);
   };
 
   try {
+    console.info("[http]", method, target);
+    return await execute(target);
+  } catch (error: any) {
+    console.error("[http failed]", error?.name || "", error?.message || error);
 
-    console.info("[http]", method, url);
-
-    const res = await withTimeout(fetch(url, cfg), opts.timeoutMs || 15000);
-
-    const ct = res.headers.get("content-type") || "";
-    const text = await res.text();
-
-    if (!res.ok) {
-      if (ct.includes("text/html")) {
-        const snippet = (text || "").slice(0, 400);
-        throw new Error(`HTTP ${res.status}. HTML: ${snippet}`);
-      }
-      try {
-        const json = text ? JSON.parse(text) : {};
-        throw new Error(json?.detail || json?.message || `HTTP ${res.status}`);
-      } catch {
-        throw new Error(text || `HTTP ${res.status}`);
-      }
-    }
-
-    return ct.includes("application/json") ? (text ? JSON.parse(text) : {}) : (text as any);
-  } catch (e: any) {
-    console.error("[http failed]", e?.name || "", e?.message || e);
-
-    if (typeof url === "string" && url.includes("://backend:")) {
-      const fallback = url.replace("://backend:", "://localhost:");
+    if (typeof target === "string" && target.includes("://backend:")) {
+      const fallback = target.replace("://backend:", "://localhost:");
       try {
         console.warn("[http retry]", fallback);
-        const res = await withTimeout(fetch(fallback, cfg), opts.timeoutMs || 15000);
-        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-        const ct = res.headers.get("content-type") || "";
-        const text = await res.text();
-        return ct.includes("application/json") ? (text ? JSON.parse(text) : {}) : (text as any);
+        return await execute(fallback);
       } catch (e2) {
         console.error("[http retry failed]", e2);
         throw e2;
       }
     }
 
-    throw e;
+    throw error;
   }
 }

--- a/frontend/src/lib/tokens.ts
+++ b/frontend/src/lib/tokens.ts
@@ -1,0 +1,60 @@
+export type Tokens = { access: string; refresh: string };
+
+export const ACCESS_TOKEN_KEY = "access_token";
+export const REFRESH_TOKEN_KEY = "refresh_token";
+
+const hasWindow = () => typeof window !== "undefined";
+
+export function getAccessToken(): string | null {
+  if (!hasWindow()) return null;
+  try {
+    return localStorage.getItem(ACCESS_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function getRefreshToken(): string | null {
+  if (!hasWindow()) return null;
+  try {
+    return localStorage.getItem(REFRESH_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function getStoredTokens(): Tokens | null {
+  const access = getAccessToken();
+  const refresh = getRefreshToken();
+  if (!access || !refresh) return null;
+  return { access, refresh };
+}
+
+export function storeTokens(tokens: Tokens) {
+  if (!hasWindow()) return;
+  try {
+    localStorage.setItem(ACCESS_TOKEN_KEY, tokens.access);
+    localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refresh);
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+export function storeAccessToken(access: string) {
+  if (!hasWindow()) return;
+  try {
+    localStorage.setItem(ACCESS_TOKEN_KEY, access);
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+export function clearStoredTokens() {
+  if (!hasWindow()) return;
+  try {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared token helper module to read, persist and clear JWTs in localStorage
- refactor the auth and API utilities to reuse the shared token helpers
- update the HTTP service to refresh access tokens on 401 responses and retry requests automatically

## Testing
- npm run test *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c84daf1d64832d900b5eb94a9360ad