### PR TITLE
Add layout persistence for plantillas

### DIFF
--- a/backend/plantillas/migrations/0003_plantilla_layout_fields.py
+++ b/backend/plantillas/migrations/0003_plantilla_layout_fields.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("plantillas", "0002_plantilla_visual_config"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="plantilla",
+            name="layout_json",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="plantilla",
+            name="layout_version",
+            field=models.PositiveIntegerField(default=1),
+        ),
+    ]

--- a/backend/plantillas/models.py
+++ b/backend/plantillas/models.py
@@ -14,6 +14,8 @@ class Plantilla(models.Model):
     descripcion = models.TextField(null=True, blank=True)
     schema = models.JSONField()
     visual_config = models.JSONField(default=dict, blank=True)
+    layout_json = models.JSONField(default=dict, blank=True)
+    layout_version = models.PositiveIntegerField(default=1)
     version = models.PositiveIntegerField(default=1)
     estado = models.CharField(max_length=10, choices=Estado.choices, default=Estado.ACTIVO)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/plantillas/serializers.py
+++ b/backend/plantillas/serializers.py
@@ -44,3 +44,26 @@ class PlantillaSerializer(serializers.ModelSerializer):
 
 class PlantillaVisualConfigSerializer(serializers.Serializer):
     visual_config = serializers.JSONField(default=dict)
+
+
+class PlantillaLayoutSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Plantilla
+        fields = (
+            "id",
+            "layout_json",
+            "layout_version",
+            "updated_at",
+        )
+        read_only_fields = ("id", "layout_version", "updated_at")
+
+    def validate_layout_json(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Debe ser un objeto JSON")
+        return value
+
+    def update(self, instance, validated_data):
+        instance.layout_version += 1
+        instance.layout_json = validated_data.get("layout_json", instance.layout_json)
+        instance.save(update_fields=["layout_json", "layout_version"])
+        return instance

--- a/backend/plantillas/viewsets.py
+++ b/backend/plantillas/viewsets.py
@@ -2,7 +2,11 @@ from rest_framework import viewsets, decorators, response, status, filters
 from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import DjangoFilterBackend
 from .models import Plantilla
-from .serializers import PlantillaSerializer, PlantillaVisualConfigSerializer
+from .serializers import (
+    PlantillaLayoutSerializer,
+    PlantillaSerializer,
+    PlantillaVisualConfigSerializer,
+)
 
 
 class PlantillaViewSet(viewsets.ModelViewSet):
@@ -36,3 +40,15 @@ class PlantillaViewSet(viewsets.ModelViewSet):
         plantilla.visual_config = serializer.validated_data["visual_config"]
         plantilla.save(update_fields=["visual_config"])
         return response.Response(serializer.validated_data["visual_config"])
+
+    @decorators.action(detail=True, methods=["get", "put"], url_path="layout")
+    def layout(self, request, pk=None):
+        plantilla = self.get_object()
+        if request.method == "GET":
+            serializer = PlantillaLayoutSerializer(plantilla)
+            return response.Response(serializer.data)
+
+        serializer = PlantillaLayoutSerializer(instance=plantilla, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return response.Response(serializer.data)


### PR DESCRIPTION
## Summary
- add JSON layout storage fields and versioning to the Plantilla model with a new migration
- expose a dedicated serializer and viewset action to fetch and update plantilla layouts

## Testing
- DJANGO_SECRET_KEY=dummy python manage.py makemigrations plantillas *(fails: ModuleNotFoundError: No module named 'django')*
- pip install -r requirements/base.txt *(fails: Could not install packages due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c8551eca50832da709b187f3e838b1