### PR TITLE
Add API client for plantilla layouts and shared form types

### DIFF
--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,4 +1,4 @@
-// frontend/src/lib/api.ts
+// frontend/src/lib/api/index.ts
 import { clearStoredTokens, getAccessToken } from "@/lib/tokens";
 
 const ABSOLUTE_URL_REGEX = /^https?:\/\//i;

--- a/frontend/src/lib/api/plantillas.ts
+++ b/frontend/src/lib/api/plantillas.ts
@@ -1,0 +1,72 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { getJSON, putJSON } from "@/lib/api";
+import type { FormLayout } from "@/lib/forms/types";
+
+export interface PlantillaLayoutResponse {
+  id: string;
+  layout_json?: unknown;
+  layout_version?: number;
+  updated_at: string;
+}
+
+export interface PlantillaLayout {
+  id: string;
+  layout: FormLayout;
+  layoutVersion: number;
+  updatedAt: string;
+}
+
+export const DEFAULT_FORM_LAYOUT: FormLayout = { version: 1, nodes: [] };
+
+const layoutPath = (plantillaId: string) => `/api/plantillas/${plantillaId}/layout/`;
+
+function isFormLayout(value: unknown): value is FormLayout {
+  if (!value || typeof value !== "object") return false;
+  const layout = value as Partial<FormLayout>;
+  return typeof layout.version === "number" && Array.isArray(layout.nodes);
+}
+
+function toFormLayout(input: unknown): FormLayout {
+  if (isFormLayout(input)) {
+    return {
+      version: input.version,
+      nodes: Array.isArray(input.nodes) ? [...input.nodes] : [],
+    };
+  }
+  return { version: DEFAULT_FORM_LAYOUT.version, nodes: [] };
+}
+
+function normalizeLayout(response: PlantillaLayoutResponse): PlantillaLayout {
+  const layoutVersion = typeof response.layout_version === "number" ? response.layout_version : 1;
+  return {
+    id: response.id,
+    layout: toFormLayout(response.layout_json),
+    layoutVersion,
+    updatedAt: response.updated_at,
+  };
+}
+
+export async function getLayout(plantillaId: string): Promise<PlantillaLayout> {
+  const response = await getJSON<PlantillaLayoutResponse>(layoutPath(plantillaId));
+  return normalizeLayout(response);
+}
+
+export async function saveLayout(plantillaId: string, layout: FormLayout): Promise<PlantillaLayout> {
+  const response = await putJSON<PlantillaLayoutResponse>(layoutPath(plantillaId), {
+    layout_json: layout,
+  });
+  return normalizeLayout(response);
+}
+
+export const plantillasKeys = {
+  all: ["plantillas"] as const,
+  layout: (plantillaId: string) => ["plantillas", "layout", plantillaId] as const,
+};
+
+export function getPlantillaLayoutQueryOptions(plantillaId: string) {
+  return queryOptions({
+    queryKey: plantillasKeys.layout(plantillaId),
+    queryFn: () => getLayout(plantillaId),
+  });
+}

--- a/frontend/src/lib/form-builder/factory.ts
+++ b/frontend/src/lib/form-builder/factory.ts
@@ -1,10 +1,8 @@
 import { nanoid } from "nanoid";
 
-export type FieldType =
-  | "text"|"textarea"|"number"
-  | "select"|"dropdown"|"multiselect"|"select_with_filter"
-  | "date"|"document"|"sum"|"phone"|"cuit_razon_social"
-  | "info"|"group";
+import type { FieldType } from "@/lib/forms/types";
+
+export type { FieldType } from "@/lib/forms/types";
 
 const LAYOUT_DEFAULTS: Record<string, { w: number; h: number }> = {
   "ui:header": { w: 12, h: 5 },

--- a/frontend/src/lib/forms/types.ts
+++ b/frontend/src/lib/forms/types.ts
@@ -1,0 +1,201 @@
+export type FieldType =
+  | "text"
+  | "textarea"
+  | "number"
+  | "select"
+  | "dropdown"
+  | "multiselect"
+  | "select_with_filter"
+  | "date"
+  | "document"
+  | "sum"
+  | "phone"
+  | "cuit_razon_social"
+  | "info"
+  | "group";
+
+export type ConditionOperator =
+  | "eq"
+  | "ne"
+  | "in"
+  | "nin"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "contains";
+
+export type FieldCondition = {
+  key: string;
+  op: ConditionOperator;
+  value?: unknown;
+};
+
+export type SelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export type GridPlacement = {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+interface BaseFieldProps {
+  id: string;
+  type: FieldType;
+  key: string;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  helpText?: string;
+  required?: boolean;
+  defaultValue?: unknown;
+  esSubsanable?: boolean;
+  esEditableOperador?: boolean;
+  seMuestraEnGrilla?: boolean;
+  condicionesOcultar?: FieldCondition[];
+  condicionesRequerir?: FieldCondition[];
+  kind?: "field" | "ui";
+  layout?: GridPlacement;
+}
+
+export interface TextFieldProps extends BaseFieldProps {
+  type: "text" | "textarea";
+  maxLength?: number;
+  pattern?: string;
+}
+
+export interface NumberFieldProps extends BaseFieldProps {
+  type: "number";
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface DateFieldProps extends BaseFieldProps {
+  type: "date";
+  minDate?: string;
+  maxDate?: string;
+}
+
+export interface SelectFieldProps extends BaseFieldProps {
+  type: "select" | "dropdown" | "select_with_filter";
+  options: SelectOption[];
+  placeholder?: string;
+}
+
+export interface MultiSelectFieldProps extends BaseFieldProps {
+  type: "multiselect";
+  options: SelectOption[];
+  placeholder?: string;
+  maxSelections?: number;
+}
+
+export interface DocumentFieldProps extends BaseFieldProps {
+  type: "document";
+  accept?: string[];
+  maxSizeMB?: number;
+  isNewFileFlag?: boolean;
+}
+
+export interface SumFieldProps extends BaseFieldProps {
+  type: "sum";
+  decimals?: number;
+  sources?: string[];
+}
+
+export interface PhoneFieldProps extends BaseFieldProps {
+  type: "phone";
+}
+
+export interface CuitRazonSocialFieldProps extends BaseFieldProps {
+  type: "cuit_razon_social";
+}
+
+export interface InfoFieldProps extends BaseFieldProps {
+  type: "info";
+  format?: "text" | "html";
+  html?: string;
+}
+
+export interface GroupFieldProps extends BaseFieldProps {
+  type: "group";
+  children: FieldProps[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export type FieldProps =
+  | TextFieldProps
+  | NumberFieldProps
+  | DateFieldProps
+  | SelectFieldProps
+  | MultiSelectFieldProps
+  | DocumentFieldProps
+  | SumFieldProps
+  | PhoneFieldProps
+  | CuitRazonSocialFieldProps
+  | InfoFieldProps
+  | GroupFieldProps;
+
+export type ColumnSpan =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12;
+
+export interface LayoutFieldNode {
+  id: string;
+  type: "field";
+  fieldId?: string;
+  fieldKey?: string;
+  colSpan?: ColumnSpan;
+}
+
+export interface LayoutColumnNode {
+  id: string;
+  type: "column";
+  span: ColumnSpan;
+  children: LayoutChildNode[];
+}
+
+export interface LayoutRowNode {
+  id: string;
+  type: "row";
+  columns: LayoutColumnNode[];
+  gutter?: number;
+}
+
+export interface LayoutSectionNode {
+  id: string;
+  type: "section";
+  title?: string;
+  description?: string;
+  children: LayoutRowNode[];
+}
+
+export type LayoutChildNode = LayoutRowNode | LayoutFieldNode | LayoutSectionNode;
+
+export type LayoutNode =
+  | LayoutSectionNode
+  | LayoutRowNode
+  | LayoutColumnNode
+  | LayoutFieldNode;
+
+export interface FormLayout {
+  version: number;
+  nodes: Array<LayoutSectionNode | LayoutRowNode>;
+}


### PR DESCRIPTION
## Summary
- add shared TypeScript types for form fields, select options, and layout nodes
- add plantilla layout API client with normalization and TanStack Query options
- move the base API helper to lib/api/index.ts and re-export field types from the builder

## Testing
- npm run test *(fails: Vitest reports `expect` is not defined in the shared setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c8583e18bc832d9c2c44ebebd0a99f