### PR TITLE
Add runtime form renderer and layout schema support

### DIFF
--- a/frontend/src/app/(private)/plantillas/render/[id]/page.tsx
+++ b/frontend/src/app/(private)/plantillas/render/[id]/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMemo } from "react";
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+
+import { getPlantillaLayoutQueryOptions } from "@/lib/api/plantillas";
+import DynamicFormRenderer from "@/lib/forms/runtime/DynamicFormRenderer";
+import type { CollectOptions } from "@/lib/forms/zodSchemaFromLayout";
+import { PlantillasService } from "@/lib/services/plantillas";
+
+const EMPTY_FIELDS: NonNullable<CollectOptions["fields"]> = [];
+
+function extractSchemaFields(schema: unknown): NonNullable<CollectOptions["fields"]> {
+  if (!schema || typeof schema !== "object") return EMPTY_FIELDS;
+  const result: any[] = [];
+  const asArray = (value: any) => (Array.isArray(value) ? value : value ? [value] : []);
+
+  const visit = (nodes: any[]) => {
+    nodes.forEach((node) => {
+      if (!node || typeof node !== "object") return;
+      const type = String(node.type || "").toLowerCase();
+      if (type === "section") {
+        visit(asArray(node.children || node.nodes));
+        return;
+      }
+      if (type === "group") {
+        const baseKey = typeof node.key === "string" ? node.key : undefined;
+        asArray(node.children).forEach((child: any) => {
+          if (!child || typeof child !== "object") return;
+          const cloned = { ...child };
+          if (baseKey && typeof cloned.key === "string") {
+            cloned.key = `${baseKey}.${cloned.key}`;
+          }
+          result.push(cloned);
+        });
+        return;
+      }
+      result.push(node);
+    });
+  };
+
+  if (Array.isArray((schema as any).nodes)) visit((schema as any).nodes);
+  else if (Array.isArray((schema as any).sections)) visit((schema as any).sections);
+  else if (Array.isArray(schema)) visit(schema as any[]);
+
+  return result;
+}
+
+export default function PlantillaRenderPage() {
+  const params = useParams();
+  const rawId = params?.id;
+  const plantillaId = Array.isArray(rawId) ? rawId[0] : rawId ?? "";
+
+  const layoutQuery = useQuery({
+    ...getPlantillaLayoutQueryOptions(plantillaId || "placeholder"),
+    enabled: Boolean(plantillaId),
+  });
+
+  const plantillaQuery = useQuery({
+    queryKey: ["plantillas", "detail", plantillaId],
+    queryFn: () => PlantillasService.fetchPlantilla(plantillaId),
+    enabled: Boolean(plantillaId),
+  });
+
+  const schemaFields = useMemo(
+    () => extractSchemaFields(plantillaQuery.data?.schema),
+    [plantillaQuery.data?.schema]
+  );
+
+  if (!plantillaId) {
+    return (
+      <div className="rounded-xl border border-dashed border-slate-300 bg-white/70 p-6 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
+        Falta el identificador de la plantilla.
+      </div>
+    );
+  }
+
+  if (layoutQuery.isLoading || plantillaQuery.isLoading) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-200">
+        Cargando formulario…
+      </div>
+    );
+  }
+
+  if (layoutQuery.isError || !layoutQuery.data) {
+    return (
+      <div className="rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-600 dark:bg-red-900/30 dark:text-red-200">
+        No fue posible cargar el layout de la plantilla.
+      </div>
+    );
+  }
+
+  if (plantillaQuery.isError) {
+    return (
+      <div className="rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-600 dark:bg-red-900/30 dark:text-red-200">
+        No fue posible obtener los detalles de la plantilla.
+      </div>
+    );
+  }
+
+  const layout = layoutQuery.data.layout;
+  const nombre = plantillaQuery.data?.nombre ?? "Formulario";
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{nombre}</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Completá los campos para validar el comportamiento del layout.
+        </p>
+      </header>
+
+      <DynamicFormRenderer
+        layout={layout}
+        fields={schemaFields}
+        submitLabel="Enviar"
+        onSubmit={(values) => {
+          // eslint-disable-next-line no-console
+          console.log("Formulario enviado", values);
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/lib/forms/runtime/DynamicFormRenderer.tsx
+++ b/frontend/src/lib/forms/runtime/DynamicFormRenderer.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import clsx from "clsx";
+import { Fragment, useMemo } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import type {
+  FormLayout,
+  LayoutChildNode,
+  LayoutColumnNode,
+  LayoutFieldNode,
+  LayoutNode,
+  LayoutRowNode,
+  LayoutSectionNode,
+} from "@/lib/forms/types";
+import {
+  collectLayoutFields,
+  type CollectOptions,
+  type ResolvedLayoutField,
+  zodSchemaFromLayout,
+} from "@/lib/forms/zodSchemaFromLayout";
+
+import CheckboxField from "./fields/CheckboxField";
+import DateField from "./fields/DateField";
+import FileField from "./fields/FileField";
+import MultiSelectField from "./fields/MultiSelectField";
+import NumberField from "./fields/NumberField";
+import RadioField from "./fields/RadioField";
+import SelectField from "./fields/SelectField";
+import SwitchField from "./fields/SwitchField";
+import TextField from "./fields/TextField";
+import TextareaField from "./fields/TextareaField";
+
+type FieldCollection = CollectOptions["fields"];
+
+type RuntimeFieldComponent = ({
+  field,
+  name,
+}: {
+  field: any;
+  name: string;
+  layout: LayoutFieldNode;
+}) => JSX.Element | null;
+
+const FIELD_COMPONENTS: Record<string, RuntimeFieldComponent> = {
+  text: ({ field, name }) => <TextField field={field} name={name} />,
+  string: ({ field, name }) => <TextField field={field} name={name} />,
+  phone: ({ field, name }) => <TextField field={field} name={name} />,
+  cuit_razon_social: ({ field, name }) => <TextField field={field} name={name} />,
+  textarea: ({ field, name }) => <TextareaField field={field} name={name} />,
+  number: ({ field, name }) => <NumberField field={field} name={name} />,
+  int: ({ field, name }) => <NumberField field={field} name={name} />,
+  float: ({ field, name }) => <NumberField field={field} name={name} />,
+  decimal: ({ field, name }) => <NumberField field={field} name={name} />,
+  sum: ({ field, name }) => <NumberField field={field} name={name} />,
+  select: ({ field, name }) => <SelectField field={field} name={name} />,
+  dropdown: ({ field, name }) => <SelectField field={field} name={name} />,
+  select_with_filter: ({ field, name }) => <SelectField field={field} name={name} />,
+  multiselect: ({ field, name }) => <MultiSelectField field={field} name={name} />,
+  date: ({ field, name }) => <DateField field={field} name={name} />,
+  datetime: ({ field, name }) => <DateField field={field} name={name} />,
+  "datetime-local": ({ field, name }) => <DateField field={field} name={name} />,
+  radio: ({ field, name }) => <RadioField field={field} name={name} />,
+  checkbox: ({ field, name }) => <CheckboxField field={field} name={name} />,
+  boolean: ({ field, name }) => <CheckboxField field={field} name={name} />,
+  switch: ({ field, name }) => <SwitchField field={field} name={name} />,
+  file: ({ field, name }) => <FileField field={field} name={name} />,
+  document: ({ field, name }) => <FileField field={field} name={name} />,
+};
+
+const COL_SPAN_CLASS: Record<number, string> = {
+  1: "col-span-1",
+  2: "col-span-2",
+  3: "col-span-3",
+  4: "col-span-4",
+  5: "col-span-5",
+  6: "col-span-6",
+  7: "col-span-7",
+  8: "col-span-8",
+  9: "col-span-9",
+  10: "col-span-10",
+  11: "col-span-11",
+  12: "col-span-12",
+};
+
+function asArray<T>(value: T | T[] | undefined | null): T[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function colSpanClass(span?: number) {
+  if (typeof span !== "number") return COL_SPAN_CLASS[12];
+  const normalized = Math.min(12, Math.max(1, Math.round(span)));
+  return COL_SPAN_CLASS[normalized] ?? COL_SPAN_CLASS[12];
+}
+
+function getFieldComponent(field: any): RuntimeFieldComponent | undefined {
+  const type = typeof field?.type === "string" ? field.type.toLowerCase() : "";
+  return FIELD_COMPONENTS[type];
+}
+
+type ResolvedMap = Map<string, ResolvedLayoutField>;
+
+function buildResolvedMap(fields: ResolvedLayoutField[]): ResolvedMap {
+  const map: ResolvedMap = new Map();
+  fields.forEach((resolved) => {
+    const keys = [
+      resolved.node.id,
+      resolved.node.fieldId,
+      resolved.node.fieldKey,
+      (resolved.field as any)?.id,
+      (resolved.field as any)?.key,
+    ].filter((key): key is string => typeof key === "string" && key.length > 0);
+    keys.push(resolved.name);
+    keys.forEach((key) => {
+      if (!map.has(key)) {
+        map.set(key, resolved);
+      }
+    });
+  });
+  return map;
+}
+
+export interface DynamicFormRendererProps {
+  layout?: FormLayout | null;
+  fields?: FieldCollection;
+  initialValues?: Record<string, unknown>;
+  onSubmit?: (values: Record<string, unknown>) => void;
+  submitLabel?: string;
+  className?: string;
+}
+
+export default function DynamicFormRenderer({
+  layout,
+  fields,
+  initialValues,
+  onSubmit,
+  submitLabel = "Guardar",
+  className,
+}: DynamicFormRendererProps) {
+  const resolvedFields = useMemo(() => collectLayoutFields(layout, { fields }), [layout, fields]);
+
+  const resolvedMap = useMemo(() => buildResolvedMap(resolvedFields), [resolvedFields]);
+
+  const schema = useMemo(() => zodSchemaFromLayout(layout, { fields }), [layout, fields]);
+
+  const defaultValues = useMemo(() => {
+    const defaults: Record<string, unknown> = { ...(initialValues ?? {}) };
+    resolvedFields.forEach(({ field, name }) => {
+      if (defaults[name] !== undefined) return;
+      if (field && typeof field === "object" && "defaultValue" in field && (field as any).defaultValue !== undefined) {
+        defaults[name] = (field as any).defaultValue;
+        return;
+      }
+      const type = typeof field?.type === "string" ? field.type.toLowerCase() : "";
+      if (type === "multiselect" && defaults[name] === undefined) defaults[name] = [];
+      if (["checkbox", "switch", "boolean"].includes(type) && defaults[name] === undefined) {
+        defaults[name] = false;
+      }
+    });
+    return defaults;
+  }, [resolvedFields, initialValues]);
+
+  const methods = useForm({
+    resolver: zodResolver(schema),
+    defaultValues,
+    mode: "onBlur",
+  });
+
+  const submitHandler = onSubmit ?? ((values: Record<string, unknown>) => console.log("Form submit", values));
+
+  const renderField = (node: LayoutFieldNode, withinColumn = false) => {
+    const lookupKeys = [node.id, node.fieldId, node.fieldKey].filter(
+      (key): key is string => typeof key === "string" && key.length > 0
+    );
+    let resolved: ResolvedLayoutField | undefined;
+    for (const key of lookupKeys) {
+      resolved = resolvedMap.get(key);
+      if (resolved) break;
+    }
+    if (!resolved) {
+      resolved = resolvedMap.get(node.id);
+    }
+    if (!resolved) {
+      const missingClass = withinColumn ? "" : colSpanClass(node.colSpan);
+      return (
+        <div
+          key={node.id}
+          className={clsx(
+            missingClass,
+            "rounded-lg border border-dashed border-red-300 bg-red-50/50 p-3 text-sm text-red-600 dark:border-red-500/60 dark:bg-red-500/10"
+          )}
+        >
+          Campo no disponible
+        </div>
+      );
+    }
+
+    const component = getFieldComponent(resolved.field);
+    const wrapperClass = withinColumn ? undefined : colSpanClass(resolved.node.colSpan);
+
+    if (!component) {
+      return (
+        <div
+          key={resolved.node.id}
+          className={clsx(
+            wrapperClass,
+            "rounded-lg border border-dashed border-amber-300 bg-amber-50/60 p-3 text-sm text-amber-700 dark:border-amber-500/70 dark:bg-amber-500/10"
+          )}
+        >
+          Tipo de campo "{resolved.field?.type ?? "desconocido"}" sin soporte
+        </div>
+      );
+    }
+
+    return (
+      <div key={resolved.node.id} className={wrapperClass}>
+        {component({ field: resolved.field, name: resolved.name, layout: resolved.node })}
+      </div>
+    );
+  };
+
+  const renderChild = (child: LayoutChildNode, withinColumn = false): JSX.Element | null => {
+    if (!child) return null;
+    if ((child as LayoutSectionNode).type === "section") {
+      return renderSection(child as LayoutSectionNode);
+    }
+    if ((child as LayoutRowNode).type === "row") {
+      return renderRow(child as LayoutRowNode);
+    }
+    if ((child as LayoutFieldNode).type === "field") {
+      return renderField(child as LayoutFieldNode, withinColumn);
+    }
+    return null;
+  };
+
+  const renderColumn = (column: LayoutColumnNode, index = 0): JSX.Element => {
+    const spanClass = colSpanClass(column.span);
+    const key = column.id ?? `column-${index}`;
+    return (
+      <div key={key} className={clsx(spanClass, "space-y-4")}> 
+        {asArray(column.children).map((child, childIndex) => (
+          <Fragment key={(child as any)?.id ?? `${key}-child-${childIndex}`}>
+            {renderChild(child, true)}
+          </Fragment>
+        ))}
+      </div>
+    );
+  };
+
+  const renderRow = (row: LayoutRowNode): JSX.Element => {
+    const columns = asArray(row.columns);
+    const gutter = typeof row.gutter === "number" ? row.gutter : 16;
+    return (
+      <div
+        key={row.id}
+        className="grid grid-cols-12"
+        style={{ columnGap: `${gutter}px`, rowGap: `${gutter}px` }}
+      >
+        {columns.length > 0
+          ? columns.map((column, columnIndex) => renderColumn(column, columnIndex))
+          : asArray((row as any).children).map((child, index) => (
+              <Fragment key={(child as any)?.id ?? `${row.id}-field-${index}`}>
+                {renderField(child as LayoutFieldNode)}
+              </Fragment>
+            ))}
+      </div>
+    );
+  };
+
+  const renderSection = (section: LayoutSectionNode): JSX.Element => {
+    const rows = asArray(section.children);
+    return (
+      <section
+        key={section.id}
+        className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/40"
+      >
+        {(section.title || section.description) && (
+          <header className="space-y-1">
+            {section.title ? (
+              <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{section.title}</h2>
+            ) : null}
+            {section.description ? (
+              <p className="text-sm text-slate-500 dark:text-slate-400">{section.description}</p>
+            ) : null}
+          </header>
+        )}
+        <div className="space-y-4">
+          {rows.map((row) => renderRow(row))}
+        </div>
+      </section>
+    );
+  };
+
+  const renderNode = (node: LayoutNode): JSX.Element | null => {
+    if (!node) return null;
+    switch (node.type) {
+      case "section":
+        return renderSection(node as LayoutSectionNode);
+      case "row":
+        return renderRow(node as LayoutRowNode);
+      case "column":
+        return renderColumn(node as LayoutColumnNode);
+      case "field":
+        return renderField(node as LayoutFieldNode);
+      default:
+        return null;
+    }
+  };
+
+  if (!layout || !asArray(layout.nodes).length) {
+    return (
+      <div className="rounded-xl border border-dashed border-slate-300 bg-white/70 p-6 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
+        No hay campos configurados en este formulario.
+      </div>
+    );
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        onSubmit={methods.handleSubmit(submitHandler)}
+        className={clsx("space-y-6", className)}
+        noValidate
+      >
+        {asArray(layout.nodes).map((node, index) => (
+          <Fragment key={(node as any)?.id ?? `node-${index}`}>
+            {renderNode(node as LayoutNode)}
+          </Fragment>
+        ))}
+
+        <div className="pt-2">
+          <Button type="submit">{submitLabel}</Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/CheckboxField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/CheckboxField.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import clsx from "clsx";
+import { useController, useFormContext } from "react-hook-form";
+
+import type { FieldProps } from "@/lib/forms/types";
+
+import { FieldWrapper, checkboxBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: (FieldProps & { type?: string }) | { type?: string; [key: string]: any };
+  name: string;
+};
+
+export default function CheckboxField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const checked = !!controllerField.value;
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+      renderLabel={false}
+    >
+      <label
+        htmlFor={id}
+        className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200"
+      >
+        <input
+          id={id}
+          type="checkbox"
+          className={clsx(checkboxBaseClass, "shrink-0")}
+          checked={checked}
+          onChange={(event) => controllerField.onChange(event.target.checked)}
+          onBlur={controllerField.onBlur}
+        />
+        <span>
+          {field.label}
+          {field.required ? <span className="ml-1 text-red-600">*</span> : null}
+        </span>
+      </label>
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/DateField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/DateField.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useController, useFormContext } from "react-hook-form";
+
+import type { DateFieldProps } from "@/lib/forms/types";
+
+import { FieldWrapper, inputBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: DateFieldProps & { type?: string };
+  name: string;
+};
+
+function formatDateValue(value: unknown) {
+  if (!value) return "";
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === "string") {
+    return value.split("T")[0];
+  }
+  return "";
+}
+
+export default function DateField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const value = formatDateValue(controllerField.value);
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <input
+        id={id}
+        type="date"
+        value={value}
+        onChange={(event) => controllerField.onChange(event.target.value || undefined)}
+        onBlur={controllerField.onBlur}
+        min={field.minDate}
+        max={field.maxDate}
+        className={inputBaseClass}
+      />
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/FileField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/FileField.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useController, useFormContext } from "react-hook-form";
+
+import type { DocumentFieldProps } from "@/lib/forms/types";
+
+import { FieldWrapper, inputBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: (DocumentFieldProps & { type?: string }) | { type?: string; [key: string]: any };
+  name: string;
+};
+
+function getFileSummary(value: unknown) {
+  if (!value) return null;
+  if (value instanceof File) {
+    return value.name;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (item instanceof File ? item.name : undefined))
+      .filter(Boolean)
+      .join(", ");
+  }
+  if (value instanceof FileList) {
+    return Array.from(value)
+      .map((f) => f.name)
+      .join(", ");
+  }
+  return null;
+}
+
+export default function FileField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const summary = getFileSummary(controllerField.value);
+  const accept = Array.isArray(field.accept) ? field.accept.join(",") : field.accept;
+  const isMultiple = Boolean((field as any)?.multiple);
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <input
+        id={id}
+        type="file"
+        accept={accept}
+        multiple={isMultiple}
+        onChange={(event) => {
+          const files = event.target.files;
+          if (!files || files.length === 0) {
+            controllerField.onChange(undefined);
+            return;
+          }
+          controllerField.onChange(isMultiple ? Array.from(files) : files[0]);
+        }}
+        onBlur={controllerField.onBlur}
+        className={inputBaseClass}
+      />
+      {summary ? (
+        <p className="text-xs text-slate-500 dark:text-slate-400">Archivo seleccionado: {summary}</p>
+      ) : null}
+      {typeof field.maxSizeMB === "number" ? (
+        <p className="text-[11px] text-slate-500 dark:text-slate-400">
+          Tamaño máximo: {field.maxSizeMB} MB
+        </p>
+      ) : null}
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/MultiSelectField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/MultiSelectField.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useController, useFormContext } from "react-hook-form";
+
+import type { MultiSelectFieldProps, SelectOption } from "@/lib/forms/types";
+
+import { FieldWrapper, selectBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field:
+    | (MultiSelectFieldProps & { type?: string })
+    | { type?: string; options?: SelectOption[]; maxSelections?: number; [key: string]: any };
+  name: string;
+};
+
+export default function MultiSelectField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const value: string[] = Array.isArray(controllerField.value)
+    ? controllerField.value.map((v) => String(v))
+    : [];
+  const options: SelectOption[] = Array.isArray(field.options)
+    ? field.options.filter((opt): opt is SelectOption => !!opt && typeof opt.value === "string")
+    : [];
+  const maxSelections = typeof field.maxSelections === "number" ? field.maxSelections : undefined;
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <select
+        id={id}
+        multiple
+        value={value}
+        onChange={(event) => {
+          const selected = Array.from(event.target.selectedOptions).map((opt) => opt.value);
+          const next = maxSelections ? selected.slice(0, maxSelections) : selected;
+          controllerField.onChange(next);
+        }}
+        onBlur={controllerField.onBlur}
+        className={`${selectBaseClass} h-32`}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value} disabled={opt.disabled}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {maxSelections ? (
+        <p className="text-[11px] text-slate-500 dark:text-slate-400">
+          Máximo {maxSelections} opción{maxSelections === 1 ? "" : "es"}
+        </p>
+      ) : null}
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/NumberField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/NumberField.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useController, useFormContext } from "react-hook-form";
+
+import type { NumberFieldProps } from "@/lib/forms/types";
+
+import { FieldWrapper, inputBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: NumberFieldProps & { type?: string };
+  name: string;
+};
+
+export default function NumberField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const value = controllerField.value;
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <input
+        id={id}
+        type="number"
+        inputMode="decimal"
+        value={value ?? ""}
+        onChange={(event) => {
+          const raw = event.target.value;
+          if (raw === "") {
+            controllerField.onChange(undefined);
+            return;
+          }
+          const next = Number(raw);
+          controllerField.onChange(Number.isNaN(next) ? undefined : next);
+        }}
+        onBlur={controllerField.onBlur}
+        min={field.min}
+        max={field.max}
+        step={field.step}
+        className={inputBaseClass}
+      />
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/RadioField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/RadioField.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import clsx from "clsx";
+import { useController, useFormContext } from "react-hook-form";
+
+import type { SelectOption } from "@/lib/forms/types";
+
+import { FieldWrapper, checkboxBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: { id?: string; label?: string; required?: boolean; description?: string; helpText?: string; options?: SelectOption[]; [key: string]: any };
+  name: string;
+};
+
+export default function RadioField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const value = controllerField.value ?? "";
+  const options: SelectOption[] = Array.isArray(field.options)
+    ? field.options.filter((opt): opt is SelectOption => !!opt && typeof opt.value === "string")
+    : [];
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <div className="space-y-2">
+        {options.map((opt) => {
+          const optionId = `${id}-${opt.value}`;
+          return (
+            <label
+              key={opt.value}
+              htmlFor={optionId}
+              className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200"
+            >
+              <input
+                id={optionId}
+                type="radio"
+                name={name}
+                className={clsx(checkboxBaseClass, "rounded-full")}
+                value={opt.value}
+                checked={value === opt.value}
+                onChange={() => controllerField.onChange(opt.value)}
+                onBlur={controllerField.onBlur}
+                disabled={opt.disabled}
+              />
+              <span>{opt.label}</span>
+            </label>
+          );
+        })}
+      </div>
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/SelectField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/SelectField.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useController, useFormContext } from "react-hook-form";
+
+import type { SelectFieldProps, SelectOption } from "@/lib/forms/types";
+
+import { FieldWrapper, selectBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: (SelectFieldProps & { type?: string }) | { type?: string; options?: SelectOption[]; [key: string]: any };
+  name: string;
+};
+
+export default function SelectField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const value = controllerField.value ?? "";
+  const options: SelectOption[] = Array.isArray(field.options)
+    ? field.options.filter((opt): opt is SelectOption => !!opt && typeof opt.value === "string")
+    : [];
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => {
+          const next = event.target.value;
+          controllerField.onChange(next === "" ? undefined : next);
+        }}
+        onBlur={controllerField.onBlur}
+        className={selectBaseClass}
+      >
+        <option value="" disabled={field.required}>
+          {field.placeholder ?? "Seleccione una opción"}
+        </option>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value} disabled={opt.disabled}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/SwitchField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/SwitchField.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import clsx from "clsx";
+import { useController, useFormContext } from "react-hook-form";
+
+import type { FieldProps } from "@/lib/forms/types";
+
+import { FieldWrapper, useFieldError } from "./shared";
+
+type Props = {
+  field: (FieldProps & { type?: string }) | { type?: string; [key: string]: any };
+  name: string;
+};
+
+export default function SwitchField({ field, name }: Props) {
+  const { control } = useFormContext();
+  const { field: controllerField } = useController({ name, control });
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+  const checked = !!controllerField.value;
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+      renderLabel={false}
+    >
+      <label
+        htmlFor={id}
+        className="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-200"
+      >
+        <button
+          id={id}
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          onClick={() => controllerField.onChange(!checked)}
+          onBlur={controllerField.onBlur}
+          className={clsx(
+            "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer items-center rounded-full border transition",
+            checked
+              ? "border-transparent bg-blue-600"
+              : "border-slate-300 bg-slate-200 dark:border-slate-600 dark:bg-slate-700"
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className={clsx(
+              "inline-block h-5 w-5 transform rounded-full bg-white shadow transition",
+              checked ? "translate-x-5" : "translate-x-1"
+            )}
+          />
+        </button>
+        <span>
+          {field.label}
+          {field.required ? <span className="ml-1 text-red-600">*</span> : null}
+        </span>
+      </label>
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/TextField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/TextField.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+
+import type { TextFieldProps } from "@/lib/forms/types";
+
+import { FieldWrapper, inputBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: TextFieldProps & { type?: string };
+  name: string;
+};
+
+export default function TextField({ field, name }: Props) {
+  const { register } = useFormContext();
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <input
+        id={id}
+        type="text"
+        {...register(name)}
+        placeholder={field.placeholder ?? ""}
+        maxLength={field.maxLength}
+        className={inputBaseClass}
+      />
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/TextareaField.tsx
+++ b/frontend/src/lib/forms/runtime/fields/TextareaField.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+
+import type { TextFieldProps } from "@/lib/forms/types";
+
+import { FieldWrapper, textareaBaseClass, useFieldError } from "./shared";
+
+type Props = {
+  field: TextFieldProps & { type?: string };
+  name: string;
+};
+
+export default function TextareaField({ field, name }: Props) {
+  const { register } = useFormContext();
+  const { error } = useFieldError(name);
+  const id = field.id ?? name;
+
+  return (
+    <FieldWrapper
+      id={id}
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      helpText={field.helpText}
+      error={error}
+    >
+      <textarea
+        id={id}
+        {...register(name)}
+        placeholder={field.placeholder ?? ""}
+        maxLength={field.maxLength}
+        className={textareaBaseClass}
+      />
+    </FieldWrapper>
+  );
+}

--- a/frontend/src/lib/forms/runtime/fields/shared.tsx
+++ b/frontend/src/lib/forms/runtime/fields/shared.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import clsx from "clsx";
+import { ReactNode } from "react";
+import { useFormContext } from "react-hook-form";
+
+export const inputBaseClass =
+  "flex h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus-visible:ring-blue-400";
+
+export const textareaBaseClass =
+  "min-h-[120px] w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus-visible:ring-blue-400";
+
+export const selectBaseClass =
+  "flex h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus-visible:ring-blue-400";
+
+export const checkboxBaseClass =
+  "h-4 w-4 rounded border border-slate-300 text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 dark:border-slate-600";
+
+interface FieldWrapperProps {
+  id: string;
+  label?: string;
+  required?: boolean;
+  description?: string | null;
+  helpText?: string | null;
+  error?: string | null;
+  children: ReactNode;
+  className?: string;
+  renderLabel?: boolean;
+}
+
+export function FieldWrapper({
+  id,
+  label,
+  required,
+  description,
+  helpText,
+  error,
+  children,
+  className,
+  renderLabel = true,
+}: FieldWrapperProps) {
+  return (
+    <div className={clsx("space-y-2", className)}>
+      {renderLabel && label ? (
+        <label
+          htmlFor={id}
+          className="text-sm font-medium text-slate-700 dark:text-slate-200"
+        >
+          {label}
+          {required ? <span className="ml-1 text-red-600">*</span> : null}
+        </label>
+      ) : null}
+      {children}
+      {description ? (
+        <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>
+      ) : null}
+      {helpText ? (
+        <p className="text-xs text-slate-500 dark:text-slate-400">{helpText}</p>
+      ) : null}
+      {error ? (
+        <p className="text-xs font-medium text-red-600">{error}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export function useFieldError(name: string) {
+  const { getFieldState, formState } = useFormContext();
+  const state = getFieldState(name, formState);
+  return {
+    error: state.error?.message ?? null,
+    invalid: state.invalid,
+  };
+}

--- a/frontend/src/lib/forms/zodSchemaFromLayout.ts
+++ b/frontend/src/lib/forms/zodSchemaFromLayout.ts
@@ -1,0 +1,406 @@
+import { z } from "zod";
+
+import type {
+  FieldProps,
+  FormLayout,
+  LayoutChildNode,
+  LayoutColumnNode,
+  LayoutFieldNode,
+  LayoutNode,
+  LayoutRowNode,
+  LayoutSectionNode,
+  SelectOption,
+} from "@/lib/forms/types";
+
+type FieldLike =
+  | (FieldProps & { type?: string; [key: string]: any })
+  | ({
+      id?: string;
+      key?: string;
+      type?: string;
+      label?: string;
+      required?: boolean;
+      description?: string | null;
+      helpText?: string | null;
+      placeholder?: string | null;
+      defaultValue?: unknown;
+      options?: SelectOption[];
+      min?: number;
+      max?: number;
+      minLength?: number;
+      maxLength?: number;
+      pattern?: string;
+      minDate?: string;
+      maxDate?: string;
+      maxSelections?: number;
+      accept?: string[] | string;
+      [key: string]: any;
+    } & Record<string, unknown>);
+
+type FieldCollection = FieldLike[] | Record<string, FieldLike> | undefined;
+
+type Lookup = {
+  byId: Map<string, FieldLike>;
+  byKey: Map<string, FieldLike>;
+};
+
+export interface CollectOptions {
+  fields?: FieldCollection;
+}
+
+export interface ResolvedLayoutField {
+  field: FieldLike;
+  node: LayoutFieldNode;
+  name: string;
+}
+
+const EMPTY_LAYOUT: FormLayout = { version: 1, nodes: [] };
+
+function addCandidate(lookup: Lookup, candidate: unknown) {
+  if (!candidate || typeof candidate !== "object") return;
+  const maybeField = candidate as FieldLike;
+  const type = typeof maybeField.type === "string" ? maybeField.type : undefined;
+  if (!type) return;
+  const id = typeof maybeField.id === "string" ? maybeField.id : undefined;
+  const key = typeof maybeField.key === "string" ? maybeField.key : undefined;
+  if (id) lookup.byId.set(id, maybeField);
+  if (key) lookup.byKey.set(key, maybeField);
+}
+
+function scanForFields(value: unknown, lookup: Lookup) {
+  if (!value || typeof value !== "object") return;
+  const node = value as Record<string, unknown>;
+  if (node.type && typeof node.type === "string" && node.type !== "section" && node.type !== "row" && node.type !== "column") {
+    addCandidate(lookup, node);
+  }
+  if ("field" in node) addCandidate(lookup, node.field);
+  if ("fieldProps" in node) addCandidate(lookup, node.fieldProps);
+  if ("data" in node) addCandidate(lookup, node.data);
+  if ("fields" in node && Array.isArray(node.fields)) node.fields.forEach((child) => scanForFields(child, lookup));
+  if (Array.isArray((node as any).children)) (node as any).children.forEach((child: unknown) => scanForFields(child, lookup));
+  if (Array.isArray((node as any).columns)) (node as any).columns.forEach((child: unknown) => scanForFields(child, lookup));
+  if (Array.isArray((node as any).nodes)) (node as any).nodes.forEach((child: unknown) => scanForFields(child, lookup));
+}
+
+function buildLookup(layout: FormLayout, extra?: FieldCollection): Lookup {
+  const lookup: Lookup = { byId: new Map(), byKey: new Map() };
+
+  if (Array.isArray(layout.nodes)) {
+    layout.nodes.forEach((node) => scanForFields(node, lookup));
+  }
+
+  if (extra) {
+    if (Array.isArray(extra)) {
+      extra.forEach((field) => addCandidate(lookup, field));
+    } else {
+      Object.values(extra).forEach((field) => addCandidate(lookup, field));
+    }
+  }
+
+  const layoutAny = layout as any;
+  if (Array.isArray(layoutAny.fields)) layoutAny.fields.forEach((field: unknown) => addCandidate(lookup, field));
+  if (layoutAny.fields && typeof layoutAny.fields === "object" && !Array.isArray(layoutAny.fields)) {
+    Object.values(layoutAny.fields).forEach((field: unknown) => addCandidate(lookup, field));
+  }
+
+  return lookup;
+}
+
+function resolveFieldFromLookup(node: LayoutFieldNode, lookup: Lookup): FieldLike | null {
+  const anyNode = node as unknown as Record<string, unknown>;
+  if (anyNode.field) {
+    const candidate = anyNode.field as FieldLike;
+    if (candidate && typeof candidate.type === "string") return candidate;
+  }
+  if (anyNode.fieldProps) {
+    const candidate = anyNode.fieldProps as FieldLike;
+    if (candidate && typeof candidate.type === "string") return candidate;
+  }
+  if (anyNode.data) {
+    const candidate = anyNode.data as FieldLike;
+    if (candidate && typeof candidate.type === "string") return candidate;
+  }
+  if (anyNode.kind === "field" && typeof anyNode.type === "string" && anyNode.type !== "field") {
+    return anyNode as unknown as FieldLike;
+  }
+
+  const idsToCheck = [node.fieldId, (anyNode.field as any)?.id, anyNode.id].filter(
+    (id): id is string => typeof id === "string"
+  );
+  for (const id of idsToCheck) {
+    const match = lookup.byId.get(id);
+    if (match) return match;
+  }
+
+  const keysToCheck = [node.fieldKey, anyNode.key, (anyNode.field as any)?.key].filter(
+    (key): key is string => typeof key === "string"
+  );
+  for (const key of keysToCheck) {
+    const match = lookup.byKey.get(key);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+function isLayoutFieldNode(node: LayoutNode | LayoutChildNode): node is LayoutFieldNode {
+  return node && typeof node === "object" && (node as any).type === "field";
+}
+
+function ensureArray<T>(value: T | T[] | undefined | null): T[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function traverseChildren(
+  node: LayoutNode | LayoutChildNode,
+  lookup: Lookup,
+  acc: ResolvedLayoutField[],
+  usedNames: Set<string>,
+  fallbackIndex: { current: number }
+) {
+  if (!node || typeof node !== "object") return;
+
+  if ((node as LayoutSectionNode).type === "section") {
+    const section = node as LayoutSectionNode;
+    ensureArray(section.children).forEach((child) => traverseChildren(child, lookup, acc, usedNames, fallbackIndex));
+    return;
+  }
+
+  if ((node as LayoutRowNode).type === "row") {
+    const row = node as LayoutRowNode;
+    ensureArray(row.columns).forEach((column) => traverseChildren(column, lookup, acc, usedNames, fallbackIndex));
+    return;
+  }
+
+  if ((node as LayoutColumnNode).type === "column") {
+    const column = node as LayoutColumnNode;
+    ensureArray(column.children).forEach((child) => traverseChildren(child, lookup, acc, usedNames, fallbackIndex));
+    return;
+  }
+
+  if (isLayoutFieldNode(node)) {
+    const fieldNode = node as LayoutFieldNode;
+    const field = resolveFieldFromLookup(fieldNode, lookup);
+    if (!field || typeof field.type !== "string") {
+      fallbackIndex.current += 1;
+      return;
+    }
+    const baseName =
+      (typeof field.key === "string" && field.key) ||
+      (typeof fieldNode.fieldKey === "string" && fieldNode.fieldKey) ||
+      (typeof (field as any).name === "string" && (field as any).name) ||
+      (typeof fieldNode.fieldId === "string" && fieldNode.fieldId) ||
+      fieldNode.id ||
+      `field_${fallbackIndex.current + 1}`;
+    fallbackIndex.current += 1;
+
+    const safeBase = String(baseName).trim() || `field_${fallbackIndex.current}`;
+    let candidate = safeBase;
+    let suffix = 1;
+    while (usedNames.has(candidate)) {
+      candidate = `${safeBase}_${suffix++}`;
+    }
+    usedNames.add(candidate);
+
+    acc.push({ field, node: fieldNode, name: candidate });
+    return;
+  }
+
+  const anyNode = node as Record<string, unknown>;
+  if (Array.isArray(anyNode.children)) anyNode.children.forEach((child) => traverseChildren(child as any, lookup, acc, usedNames, fallbackIndex));
+  if (Array.isArray(anyNode.columns)) anyNode.columns.forEach((child) => traverseChildren(child as any, lookup, acc, usedNames, fallbackIndex));
+  if (Array.isArray(anyNode.nodes)) anyNode.nodes.forEach((child) => traverseChildren(child as any, lookup, acc, usedNames, fallbackIndex));
+}
+
+export function collectLayoutFields(layout?: FormLayout | null, options?: CollectOptions): ResolvedLayoutField[] {
+  const normalized = layout ?? EMPTY_LAYOUT;
+  const lookup = buildLookup(normalized, options?.fields);
+  const resolved: ResolvedLayoutField[] = [];
+  const usedNames = new Set<string>();
+  const fallbackIndex = { current: 0 };
+
+  ensureArray(normalized.nodes).forEach((node) => traverseChildren(node as LayoutNode, lookup, resolved, usedNames, fallbackIndex));
+
+  return resolved;
+}
+
+function preprocessNumber(value: unknown) {
+  if (value === "" || value === null || value === undefined) return undefined;
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : value;
+  }
+  return value;
+}
+
+function getOptions(field: FieldLike): string[] {
+  if (!field || typeof field !== "object") return [];
+  const raw = (field as any).options as SelectOption[] | undefined;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((opt) => {
+      if (!opt) return undefined;
+      if (typeof opt === "string") return opt;
+      if (typeof opt.value === "string") return opt.value;
+      return undefined;
+    })
+    .filter((value): value is string => typeof value === "string");
+}
+
+function schemaForField(field: FieldLike): z.ZodTypeAny | null {
+  const type = typeof field.type === "string" ? field.type.toLowerCase() : "";
+  const required = !!field.required;
+
+  if (["text", "textarea", "string", "phone", "cuit_razon_social"].includes(type)) {
+    let schema = z.string({
+      required_error: "Campo obligatorio",
+      invalid_type_error: "Debe ser texto",
+    });
+    const minLength = typeof (field as any).minLength === "number" ? (field as any).minLength : undefined;
+    const maxLength = typeof (field as any).maxLength === "number" ? (field as any).maxLength : undefined;
+    if (typeof minLength === "number") schema = schema.min(minLength);
+    if (typeof maxLength === "number") schema = schema.max(maxLength);
+    if (field.pattern) {
+      try {
+        schema = schema.regex(new RegExp(field.pattern));
+      } catch {
+        /* ignore invalid pattern */
+      }
+    }
+    return required ? schema.min(1, { message: "Campo obligatorio" }) : schema.optional();
+  }
+
+  if (["number", "int", "float", "decimal", "sum"].includes(type)) {
+    if (required) {
+      let schema = z.preprocess(
+        preprocessNumber,
+        z.number({ required_error: "Campo obligatorio", invalid_type_error: "Debe ser un número" })
+      );
+      if (typeof field.min === "number") schema = schema.min(field.min, { message: `Debe ser ≥ ${field.min}` });
+      if (typeof field.max === "number") schema = schema.max(field.max, { message: `Debe ser ≤ ${field.max}` });
+      return schema;
+    }
+    let schema = z
+      .preprocess(preprocessNumber, z.number({ invalid_type_error: "Debe ser un número" }))
+      .optional();
+    if (typeof field.min === "number") {
+      schema = schema.refine((value) => value === undefined || value >= field.min!, {
+        message: `Debe ser ≥ ${field.min}`,
+      });
+    }
+    if (typeof field.max === "number") {
+      schema = schema.refine((value) => value === undefined || value <= field.max!, {
+        message: `Debe ser ≤ ${field.max}`,
+      });
+    }
+    return schema;
+  }
+
+  if (type === "date" || type === "datetime" || type === "datetime-local") {
+    const parseDate = (value: unknown) => {
+      if (value === "" || value === null || value === undefined) return undefined;
+      if (value instanceof Date) return value;
+      if (typeof value === "string") {
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? value : parsed;
+      }
+      return value;
+    };
+    const minDate = field.minDate ? new Date(field.minDate) : undefined;
+    const maxDate = field.maxDate ? new Date(field.maxDate) : undefined;
+
+    if (required) {
+      let schema = z.preprocess(
+        parseDate,
+        z.date({ required_error: "Campo obligatorio", invalid_type_error: "Fecha inválida" })
+      );
+      if (minDate && !Number.isNaN(minDate.getTime())) {
+        schema = schema.refine((value) => value >= minDate, {
+          message: `Debe ser posterior a ${minDate.toISOString().slice(0, 10)}`,
+        });
+      }
+      if (maxDate && !Number.isNaN(maxDate.getTime())) {
+        schema = schema.refine((value) => value <= maxDate, {
+          message: `Debe ser anterior a ${maxDate.toISOString().slice(0, 10)}`,
+        });
+      }
+      return schema;
+    }
+    let schema = z.preprocess(parseDate, z.date({ invalid_type_error: "Fecha inválida" })).optional();
+    if (minDate && !Number.isNaN(minDate.getTime())) {
+      schema = schema.refine((value) => value === undefined || value >= minDate, {
+        message: `Debe ser posterior a ${minDate.toISOString().slice(0, 10)}`,
+      });
+    }
+    if (maxDate && !Number.isNaN(maxDate.getTime())) {
+      schema = schema.refine((value) => value === undefined || value <= maxDate, {
+        message: `Debe ser anterior a ${maxDate.toISOString().slice(0, 10)}`,
+      });
+    }
+    return schema;
+  }
+
+  if (["select", "dropdown", "select_with_filter", "radio"].includes(type)) {
+    const values = getOptions(field);
+    if (values.length >= 1) {
+      const enumSchema = z.enum(values as [string, ...string[]], {
+        required_error: "Campo obligatorio",
+      });
+      return required ? enumSchema : enumSchema.optional();
+    }
+    let schema = z.string({ required_error: "Campo obligatorio" });
+    return required ? schema.min(1, { message: "Campo obligatorio" }) : schema.optional();
+  }
+
+  if (type === "multiselect") {
+    let schema = z.array(z.string());
+    if (required) schema = schema.min(1, { message: "Seleccione al menos una opción" });
+    if (typeof field.maxSelections === "number") {
+      schema = schema.max(field.maxSelections, {
+        message: `Puede seleccionar hasta ${field.maxSelections}`,
+      });
+    }
+    return required ? schema : schema.optional();
+  }
+
+  if (["checkbox", "switch", "boolean"].includes(type)) {
+    let schema = z.boolean();
+    if (required) {
+      return schema.refine((value) => value === true, { message: "Debe estar marcado" });
+    }
+    return schema.optional();
+  }
+
+  if (type === "file" || type === "document") {
+    let schema: z.ZodTypeAny = z.any();
+    if (required) {
+      schema = schema.refine((value) => value != null, { message: "Archivo requerido" });
+    } else {
+      schema = schema.optional();
+    }
+    return schema;
+  }
+
+  if (type === "info" || type === "group") {
+    return null;
+  }
+
+  const fallback = z.any();
+  return required ? fallback : fallback.optional();
+}
+
+export function zodSchemaFromLayout(layout?: FormLayout | null, options?: CollectOptions) {
+  const fields = collectLayoutFields(layout ?? EMPTY_LAYOUT, options);
+  const shape: Record<string, z.ZodTypeAny> = {};
+
+  fields.forEach(({ field, name }) => {
+    const schema = schemaForField(field);
+    if (schema) {
+      shape[name] = schema;
+    }
+  });
+
+  return z.object(shape);
+}


### PR DESCRIPTION
## Summary
- add reusable ShadCN-style React Hook Form field wrappers for text, number, selection, boolean, and file inputs
- derive Zod validation schemas from stored form layouts and render them with a new grid-based DynamicFormRenderer
- add a plantilla render page that loads the saved layout and schema, logging submitted data for now

## Testing
- npm run test *(fails: ReferenceError: expect is not defined in existing vitest setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c863bba554832db2425c939028a264