### PR TITLE
feat: centralize frontend API base URL

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,1 @@
-API_URL_INTERNAL=http://backend:8000
 NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,16 +1,21 @@
 /** @type {import('next').NextConfig} */
-const API_INTERNAL = process.env.API_URL_INTERNAL || "http://backend:8000";
-
 const nextConfig = {
   reactStrictMode: true,
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${API_INTERNAL.replace(/\/$/, "")}/api/:path*`,
-      },
-    ];
-  },
 };
 
 module.exports = nextConfig;
+
+// Opcional: rewrites para usar /backend si el front corre en Docker
+// module.exports = {
+//   ...nextConfig,
+//   async rewrites() {
+//     const base = process.env.NEXT_PUBLIC_API_BASE?.replace(/\/+$/, "");
+//     if (!base) return [];
+//     return [
+//       {
+//         source: "/backend/:path*",
+//         destination: `${base}/:path*`,
+//       },
+//     ];
+//   },
+// };

--- a/frontend/src/app/(private)/plantillas/render/[id]/page.tsx
+++ b/frontend/src/app/(private)/plantillas/render/[id]/page.tsx
@@ -9,6 +9,8 @@ import DynamicFormRenderer from "@/lib/forms/runtime/DynamicFormRenderer";
 import type { CollectOptions } from "@/lib/forms/zodSchemaFromLayout";
 import { PlantillasService } from "@/lib/services/plantillas";
 
+type PlantillaDetail = { schema?: unknown; nombre?: string };
+
 const EMPTY_FIELDS: NonNullable<CollectOptions["fields"]> = [];
 
 function extractSchemaFields(schema: unknown): NonNullable<CollectOptions["fields"]> {
@@ -63,9 +65,16 @@ export default function PlantillaRenderPage() {
     enabled: Boolean(plantillaId),
   });
 
+  const plantillaSchema = (
+    plantillaQuery.data as PlantillaDetail | undefined
+  )?.schema;
+  const plantillaNombre = (
+    plantillaQuery.data as PlantillaDetail | undefined
+  )?.nombre;
+
   const schemaFields = useMemo(
-    () => extractSchemaFields(plantillaQuery.data?.schema),
-    [plantillaQuery.data?.schema]
+    () => extractSchemaFields(plantillaSchema),
+    [plantillaSchema]
   );
 
   if (!plantillaId) {
@@ -101,7 +110,7 @@ export default function PlantillaRenderPage() {
   }
 
   const layout = layoutQuery.data.layout;
-  const nombre = plantillaQuery.data?.nombre ?? "Formulario";
+  const nombre = plantillaNombre ?? "Formulario";
 
   return (
     <div className="space-y-6">

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,5 +1,6 @@
 // frontend/src/lib/api/index.ts
 import { clearStoredTokens, getAccessToken } from "@/lib/tokens";
+import { apiUrl } from "@/services/api";
 
 const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
 const isServer = typeof window === "undefined";
@@ -36,20 +37,7 @@ export function resolveApiUrl(path: string): string {
   if (ABSOLUTE_URL_REGEX.test(path)) {
     return path;
   }
-  const normalized = path.startsWith("/") ? path : `/${path}`;
-
-  if (isServer) {
-    // Dentro del contenedor / SSR: hablar directo con el backend por red interna
-    const base =
-      (process.env.API_URL_INTERNAL ||
-        process.env.API_URL || // fallback por si usan esta
-        "http://backend:8000").replace(/\/$/, "");
-    return `${base}${normalized}`;
-  }
-
-  // En el navegador: si hay NEXT_PUBLIC_API_URL, úsala; si no, relativo (requiere proxy)
-  const publicBase = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "");
-  return publicBase ? `${publicBase}${normalized}` : normalized;
+  return apiUrl(path);
 }
 
 /** Construye la URL final y aplica slash según método */

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { login as requestLogin, me as requestMe, refreshToken } from "@/lib/services/auth";
+import { login as requestLogin, me as requestMe, refreshToken } from "@/services/auth";
 import { Tokens, clearStoredTokens, getStoredTokens, storeTokens } from "@/lib/tokens";
 
 export function getTokens(): Tokens | null {

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,18 +1,5 @@
-const RAW_API_URL = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "");
-
-function normalizeForBrowser(url: string) {
-  if (typeof window !== "undefined" && url.includes("://backend:")) {
-    return url.replace("://backend:", "://localhost:");
-  }
-  return url;
-}
+import { API_BASE } from "@/services/api";
 
 export function getApiBaseUrl() {
-  let base = RAW_API_URL;
-
-  if (!base && typeof window !== "undefined") {
-    base = window.location.origin.replace(/\/$/, "");
-  }
-
-  return normalizeForBrowser(base);
+  return API_BASE;
 }

--- a/frontend/src/lib/services/legajos.ts
+++ b/frontend/src/lib/services/legajos.ts
@@ -2,7 +2,7 @@ import { getJSON, postJSON } from '@/lib/api';
 
 export const LegajosService = {
   create: (payload: { plantilla_id: string; data: any }) =>
-    postJSON(`/legajos/`, payload),
+    postJSON(`/api/legajos/`, payload),
   list: (
     params: { formId?: string; page?: number; page_size?: number; search?: string } = {}
   ) => {
@@ -12,7 +12,7 @@ export const LegajosService = {
     if (params.page_size) q.set('page_size', String(params.page_size));
     if (params.search) q.set('search', params.search);
     const qs = q.toString();
-    return getJSON(`/legajos/${qs ? `?${qs}` : ''}`);
+    return getJSON(`/api/legajos/${qs ? `?${qs}` : ''}`);
   },
-  get: (id: string) => getJSON(`/legajos/${id}/`),
+  get: (id: string) => getJSON(`/api/legajos/${id}/`),
 };

--- a/frontend/src/lib/services/plantillas.ts
+++ b/frontend/src/lib/services/plantillas.ts
@@ -27,32 +27,32 @@ const getWithFallback = (a: string, b: string) => getJSON(a).catch(() => getJSON
 export const PlantillasService = {
   fetchPlantillas: async (p: FetchPlantillasParams = {}) => {
     const qs = qsOf({ search: p.search, estado: p.estado, page: p.page, page_size: p.page_size });
-    const res = await getWithFallback(`/plantillas/${qs}`, `/formularios/${qs}`);
+    const res = await getWithFallback(`/api/plantillas/${qs}`, `/api/formularios/${qs}`);
     return normalizeList(res);
   },
 
-  fetchPlantilla: (id: string) => getWithFallback(`/plantillas/${id}/`, `/formularios/${id}/`),
+  fetchPlantilla: (id: string) => getWithFallback(`/api/plantillas/${id}/`, `/api/formularios/${id}/`),
 
   existsNombre: async (nombre: string, excludeId?: string) => {
     const qs = qsOf({ nombre: nombre?.trim(), exclude_id: excludeId });
     try {
-      const r = await getJSON(`/plantillas/exists/${qs}`);
+      const r = await getJSON(`/api/plantillas/exists/${qs}`);
       return !!r?.exists;
     } catch {
-      const r = await getJSON(`/formularios/exists/${qs}`);
+      const r = await getJSON(`/api/formularios/exists/${qs}`);
       return !!r?.exists;
     }
   },
 
   savePlantilla: (payload: any) =>
-    postJSON(`/plantillas/`, payload).catch(() => postJSON(`/formularios/`, payload)),
+    postJSON(`/api/plantillas/`, payload).catch(() => postJSON(`/api/formularios/`, payload)),
 
   updatePlantilla: (id: string, payload: any) =>
-    putJSON(`/plantillas/${id}/`, payload).catch(() => putJSON(`/formularios/${id}/`, payload)),
+    putJSON(`/api/plantillas/${id}/`, payload).catch(() => putJSON(`/api/formularios/${id}/`, payload)),
 
   updateVisualConfig: (id: string, cfg: any) =>
-    patchJSON(`/plantillas/${id}/visual-config/`, cfg),
+    patchJSON(`/api/plantillas/${id}/visual-config/`, cfg),
 
   deletePlantilla: (id: string) =>
-    deleteJSON(`/plantillas/${id}/`).catch(() => deleteJSON(`/formularios/${id}/`)),
+    deleteJSON(`/api/plantillas/${id}/`).catch(() => deleteJSON(`/api/formularios/${id}/`)),
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,14 @@
+export const API_BASE = (process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000").replace(/\/+$/, "");
+export const apiUrl = (path: string) => `${API_BASE}${path.startsWith('/') ? '' : '/'}${path}`;
+
+export async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(apiUrl(path), init);
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`;
+    try {
+      detail = (await res.json())?.detail ?? detail;
+    } catch {}
+    throw new Error(detail);
+  }
+  return res.json();
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,50 +1,43 @@
-export interface TokenPair {
-  access: string;
-  refresh: string;
-}
+import { apiUrl } from "./api";
 
-function apiBase(): string {
-  const base = process.env.NEXT_PUBLIC_API_BASE;
-  if (!base) throw new Error("NEXT_PUBLIC_API_BASE no está definido");
-  return base.replace(/\/+$/, "");
-}
+export interface TokenPair { access: string; refresh: string }
+
+function base(): string { return apiUrl("/"); } // solo para loguear base efectiva
 
 export async function login(username: string, password: string): Promise<TokenPair> {
-  const res = await fetch(`${apiBase()}/api/token/`, {
+  const url = apiUrl("/api/token/");
+  console.log("[auth] BASE =", base(), "LOGIN URL =", url);
+  const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ username, password }),
   });
   if (!res.ok) {
     let detail = `HTTP ${res.status}`;
-    try {
-      detail = (await res.json())?.detail ?? detail;
-    } catch {}
+    try { detail = (await res.json())?.detail ?? detail; } catch {}
     throw new Error(`Login failed: ${detail}`);
   }
   return res.json();
 }
 
 export async function refreshToken(refresh: string): Promise<{ access: string }> {
-  const res = await fetch(`${apiBase()}/api/token/refresh/`, {
+  const url = apiUrl("/api/token/refresh/");
+  const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ refresh }),
   });
   if (!res.ok) {
     let detail = `HTTP ${res.status}`;
-    try {
-      detail = (await res.json())?.detail ?? detail;
-    } catch {}
+    try { detail = (await res.json())?.detail ?? detail; } catch {}
     throw new Error(`Refresh failed: ${detail}`);
   }
   return res.json();
 }
 
 export async function me(access: string) {
-  const res = await fetch(`${apiBase()}/api/auth/me/`, {
-    headers: { Authorization: `Bearer ${access}` },
-  });
+  const url = apiUrl("/api/auth/me/");
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${access}` } });
   if (!res.ok) throw new Error(`Me failed: HTTP ${res.status}`);
   return res.json();
 }


### PR DESCRIPTION
### Búsquedas solicitadas
- `backend:8000`: sin coincidencias en frontend/*.ts, *.tsx o *.js.
- `/api/api/`: sin coincidencias.
- `api/api/token`: sin coincidencias.
- `baseURL`: sin coincidencias.
- `axios.create(`: sin coincidencias.
- `requests.js`: sin coincidencias.
- `AuthMe`: sin coincidencias.
- `/api/token`: frontend/src/services/auth.ts:8, frontend/src/services/auth.ts:24.

### Resumen
- Se creó `src/services/api.ts` como helper único para construir URLs absolutas y normalizar respuestas JSON con mensajes de error claros.
- Se movió el servicio de autenticación a `src/services/auth.ts`, ahora usando el helper, la nueva variable `NEXT_PUBLIC_API_BASE` y registrando la base efectiva del backend.
- Se actualizó la configuración de Next.js y el ejemplo de entorno para dejar de depender de `backend:8000`, junto con los servicios y utilidades (`src/lib/api`, `src/lib/env`, `src/lib/auth`, `src/lib/services/*`) que ahora consumen `apiUrl` y rutas `/api/...` coherentes.
- Se ajustó la página de render de plantillas para tipar la respuesta remota y evitar errores de compilación al ejecutar el build.

### Testing
- `npm run lint` (no ejecutado: requiere elegir configuración interactiva de ESLint).
- `npm run build` (falla por tipos existentes fuera del alcance: `getJSON` devuelve `unknown` en src/app/legajos/[id]/page.tsx).


------
https://chatgpt.com/codex/tasks/task_e_68c86f1a55f8832d96adf252ae2efd39