### PR TITLE
Allow local frontend origins for development

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,8 @@
-Placeholder backend directory for Django project.
+# Backend Django
+
+## Desarrollo
+
+Si el front usa otro puerto distinto a los configurados por defecto,
+agrégalo en las listas `CORS_ALLOWED_ORIGINS` y `CSRF_TRUSTED_ORIGINS`
+del archivo `config/settings.py` para permitir las solicitudes durante el
+desarrollo.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -98,15 +98,21 @@ MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+CORS_ALLOW_CREDENTIALS = True
+
+# Nota: establecer ``CORS_ALLOW_ALL_ORIGINS = True`` solo como diagnóstico
+# temporal durante el desarrollo. No se recomienda mantenerlo activo.
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:3006",
     "http://localhost:3008",
 ]
 
-CORS_ALLOW_CREDENTIALS = True
-
 CSRF_TRUSTED_ORIGINS = [
     "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:3006",
     "http://localhost:3008",
 ]
 


### PR DESCRIPTION
## Summary
- add documented localhost origins for CORS and CSRF settings used during development
- document in the backend README how to add additional frontend ports when needed

## Testing
- DJANGO_SECRET_KEY=devsecret python manage.py check *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c873b40ad0832d8e47d1fcf3ac4833