### PR TITLE
feat: support sections tabs and repeater containers

### DIFF
--- a/frontend/src/app/(private)/plantillas/render/[id]/page.tsx
+++ b/frontend/src/app/(private)/plantillas/render/[id]/page.tsx
@@ -26,6 +26,27 @@ function extractSchemaFields(schema: unknown): NonNullable<CollectOptions["field
         visit(asArray((node as any).children || (node as any).nodes));
         return;
       }
+      if (type === "tabs") {
+        const tabsChildren = (node as any).tabsChildren;
+        if (tabsChildren && typeof tabsChildren === "object") {
+          Object.values(tabsChildren).forEach((children: any) => {
+            visit(asArray(children));
+          });
+        }
+        return;
+      }
+      if (type === "repeater") {
+        const baseKey = typeof (node as any).key === "string" ? (node as any).key : undefined;
+        asArray((node as any).children).forEach((child: any) => {
+          if (!child || typeof child !== "object") return;
+          const cloned = { ...child };
+          if (baseKey && typeof cloned.key === "string") {
+            cloned.key = `${baseKey}.${cloned.key}`;
+          }
+          visit([cloned]);
+        });
+        return;
+      }
       if (type === "group") {
         const baseKey = typeof (node as any).key === "string" ? (node as any).key : undefined;
         asArray((node as any).children).forEach((child: any) => {

--- a/frontend/src/components/form/runtime/DynamicNode.tsx
+++ b/frontend/src/components/form/runtime/DynamicNode.tsx
@@ -1,4 +1,5 @@
-import { useFormContext, useWatch } from "react-hook-form";
+import { useState } from "react";
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { evalConditions } from "@/lib/form-builder/visibility";
 import TextField from "./fields/TextField";
 import NumberField from "./fields/NumberField";
@@ -27,6 +28,96 @@ export default function DynamicNode({ node, prefix="" }:{node:any, prefix?:strin
         <legend className="px-2">{node.title}</legend>
         {node.children?.map((c:any)=> <DynamicNode key={c.id} node={c} />)}
       </fieldset>
+    );
+  }
+  if (node.type === "tabs") {
+    const tabs = Array.isArray(node.tabs) ? node.tabs : [];
+    const fallbackId = tabs.find((tab: any) => typeof tab?.id === "string" && tab.id)?.id;
+    const [activeTab, setActiveTab] = useState<string>(fallbackId || "");
+    const currentId = activeTab || fallbackId || "";
+    const children = currentId && node.tabsChildren ? node.tabsChildren[currentId] : undefined;
+    return (
+      <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900/40">
+        {node.title ? (
+          <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">{node.title}</h3>
+        ) : null}
+        <div className="flex flex-wrap gap-2">
+          {tabs.map((tab: any) => {
+            const tabId = typeof tab?.id === "string" ? tab.id : "";
+            if (!tabId) return null;
+            const isActive = tabId === currentId;
+            return (
+              <button
+                type="button"
+                key={tabId}
+                onClick={() => setActiveTab(tabId)}
+                className={`rounded-md px-3 py-1 text-xs font-medium transition ${
+                  isActive
+                    ? "bg-indigo-600 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+                }`}
+              >
+                {tab?.title || "Pestaña"}
+              </button>
+            );
+          })}
+        </div>
+        <div className="space-y-3">
+          {Array.isArray(children)
+            ? children.map((child: any) => (
+                <DynamicNode key={child?.id ?? `${currentId}-${Math.random()}`} node={child} prefix={prefix} />
+              ))
+            : null}
+        </div>
+      </div>
+    );
+  }
+  if (node.type === "repeater") {
+    const name = key || node.fieldKey || node.key || node.id;
+    const { fields, append, remove } = useFieldArray({ control, name });
+    const minItems = typeof node.minItems === "number" ? node.minItems : 0;
+    const canRemove = fields.length > minItems;
+    return (
+      <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900/40">
+        {node.title ? (
+          <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">{node.title}</h3>
+        ) : null}
+        <div className="space-y-3">
+          {fields.map((item, index) => (
+            <div
+              key={item.id}
+              className="space-y-3 rounded-lg border border-slate-200 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-900/50"
+            >
+              {(node.children || []).map((child: any) => (
+                <DynamicNode
+                  key={child?.id ?? `${name}-${index}-${Math.random()}`}
+                  node={child}
+                  prefix={`${name}.${index}.`}
+                />
+              ))}
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  disabled={!canRemove}
+                  className="rounded-md border border-red-300 px-2 py-1 text-xs text-red-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500/70 dark:text-red-200"
+                >
+                  Eliminar
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => append({})}
+            className="rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            Agregar
+          </button>
+        </div>
+      </div>
     );
   }
   const field = { ...node, key };

--- a/frontend/src/lib/forms/runtime/DynamicFormRenderer.tsx
+++ b/frontend/src/lib/forms/runtime/DynamicFormRenderer.tsx
@@ -2,8 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import clsx from "clsx";
-import { Fragment, useMemo } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { Fragment, useMemo, useState } from "react";
+import { FormProvider, useForm, useFieldArray } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
 import type {
@@ -12,8 +12,10 @@ import type {
   LayoutColumnNode,
   LayoutFieldNode,
   LayoutNode,
+  LayoutRepeaterNode,
   LayoutRowNode,
   LayoutSectionNode,
+  LayoutTabsNode,
 } from "@/lib/forms/types";
 import {
   collectLayoutFields,
@@ -90,6 +92,52 @@ function asArray<T>(value: T | T[] | undefined | null): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
+function buildNameFromPath(path: string[], stack: string[]): string {
+  if (!path.length) return "";
+  const parts: string[] = [];
+  let stackIndex = 0;
+  path.forEach((segment) => {
+    if (segment === "*") {
+      const value = stack[stackIndex] ?? "0";
+      parts.push(value);
+      stackIndex += 1;
+    } else {
+      parts.push(segment);
+    }
+  });
+  return parts.join(".");
+}
+
+function getValueAtPath(target: Record<string, unknown>, path: string[]): unknown {
+  if (!path.length) return undefined;
+  let current: unknown = target;
+  for (const segment of path) {
+    if (segment === "*") return undefined;
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function setValueAtPath(target: Record<string, unknown>, path: string[], value: unknown) {
+  if (!path.length) return;
+  if (path.some((segment) => segment === "*")) return;
+  let current: Record<string, unknown> = target;
+  path.forEach((segment, index) => {
+    if (index === path.length - 1) {
+      if (current[segment] === undefined) {
+        current[segment] = value;
+      }
+      return;
+    }
+    const existing = current[segment];
+    if (!existing || typeof existing !== "object") {
+      current[segment] = {};
+    }
+    current = current[segment] as Record<string, unknown>;
+  });
+}
+
 function colSpanClass(span?: number) {
   if (typeof span !== "number") return COL_SPAN_CLASS[12];
   const normalized = Math.min(12, Math.max(1, Math.round(span)));
@@ -148,16 +196,22 @@ export default function DynamicFormRenderer({
 
   const defaultValues = useMemo(() => {
     const defaults: Record<string, unknown> = { ...(initialValues ?? {}) };
-    resolvedFields.forEach(({ field, name }) => {
-      if (defaults[name] !== undefined) return;
+    resolvedFields.forEach(({ field, path }) => {
+      if (!path.length) return;
+      if (path.some((segment) => segment === "*")) return;
+      const existing = getValueAtPath(defaults, path);
+      if (existing !== undefined) return;
       if (field && typeof field === "object" && "defaultValue" in field && (field as any).defaultValue !== undefined) {
-        defaults[name] = (field as any).defaultValue;
+        setValueAtPath(defaults, path, (field as any).defaultValue);
         return;
       }
       const type = typeof field?.type === "string" ? field.type.toLowerCase() : "";
-      if (type === "multiselect" && defaults[name] === undefined) defaults[name] = [];
-      if (["checkbox", "switch", "boolean"].includes(type) && defaults[name] === undefined) {
-        defaults[name] = false;
+      if (type === "multiselect") {
+        setValueAtPath(defaults, path, []);
+        return;
+      }
+      if (["checkbox", "switch", "boolean"].includes(type)) {
+        setValueAtPath(defaults, path, false);
       }
     });
     return defaults;
@@ -171,7 +225,11 @@ export default function DynamicFormRenderer({
 
   const submitHandler = onSubmit ?? ((values: Record<string, unknown>) => console.log("Form submit", values));
 
-  const renderField = (node: LayoutFieldNode, withinColumn = false) => {
+  const renderField = (
+    node: LayoutFieldNode,
+    withinColumn = false,
+    repeaterStack: string[] = [],
+  ) => {
     const lookupKeys = [node.id, node.fieldId, node.fieldKey].filter(
       (key): key is string => typeof key === "string" && key.length > 0
     );
@@ -215,42 +273,228 @@ export default function DynamicFormRenderer({
       );
     }
 
+    const fieldName = buildNameFromPath(resolved.path, repeaterStack);
+
     return (
       <div key={resolved.node.id} className={wrapperClass}>
-        {component({ field: resolved.field, name: resolved.name, layout: resolved.node })}
+        {component({ field: resolved.field, name: fieldName, layout: resolved.node })}
       </div>
     );
   };
 
-  const renderChild = (child: LayoutChildNode, withinColumn = false): JSX.Element | null => {
+  function TabsNodeRenderer({
+    node,
+    repeaterStack,
+  }: {
+    node: LayoutTabsNode;
+    repeaterStack: string[];
+  }) {
+    const tabs = asArray(node.tabs);
+    const childrenMap = (node.tabsChildren ?? {}) as Record<string, LayoutChildNode[] | LayoutChildNode | undefined>;
+    const fallbackTabId =
+      tabs.find((tab) => typeof tab?.id === "string" && tab.id)?.id ?? Object.keys(childrenMap)[0] ?? "";
+    const [activeTab, setActiveTab] = useState(fallbackTabId);
+
+    const effectiveTabId =
+      activeTab && (childrenMap[activeTab] !== undefined || tabs.some((tab) => tab?.id === activeTab))
+        ? activeTab
+        : fallbackTabId;
+
+    const renderTabChildren = (tabId: string) => {
+      const children = asArray(childrenMap[tabId] as LayoutChildNode[]);
+      if (children.length === 0) {
+        return (
+          <div className="rounded-lg border border-dashed border-slate-300/80 p-4 text-xs text-slate-500 dark:border-slate-600/70 dark:text-slate-400">
+            Esta pestaña no tiene campos.
+          </div>
+        );
+      }
+      return children.map((child, index) => (
+        <Fragment key={(child as any)?.id ?? `${node.id}-${tabId}-${index}`}>
+          {renderChild(child, false, repeaterStack)}
+        </Fragment>
+      ));
+    };
+
+    return (
+      <section className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+        {(node.title || node.description) && (
+          <header className="space-y-1">
+            {node.title ? (
+              <h3 className="text-base font-semibold text-slate-800 dark:text-slate-100">{node.title}</h3>
+            ) : null}
+            {node.description ? (
+              <p className="text-sm text-slate-500 dark:text-slate-400">{node.description}</p>
+            ) : null}
+          </header>
+        )}
+        <div className="flex flex-wrap gap-2 border-b border-slate-200 pb-2 dark:border-slate-700">
+          {tabs.map((tab) => {
+            const tabId = typeof tab?.id === "string" ? tab.id : "";
+            if (!tabId) return null;
+            const isActive = tabId === effectiveTabId;
+            return (
+              <button
+                type="button"
+                key={tabId}
+                onClick={() => setActiveTab(tabId)}
+                className={clsx(
+                  "rounded-md px-3 py-1 text-xs font-medium transition",
+                  isActive
+                    ? "bg-indigo-600 text-white shadow-sm"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+                )}
+              >
+                {tab?.title || "Pestaña"}
+              </button>
+            );
+          })}
+        </div>
+        <div className="space-y-4 pt-4">
+          {effectiveTabId ? renderTabChildren(effectiveTabId) : null}
+        </div>
+      </section>
+    );
+  }
+
+  function RepeaterNodeRenderer({
+    node,
+    repeaterStack,
+  }: {
+    node: LayoutRepeaterNode;
+    repeaterStack: string[];
+  }) {
+    const name =
+      (typeof node.fieldKey === "string" && node.fieldKey) ||
+      (typeof (node as any).key === "string" && (node as any).key) ||
+      (typeof (node as any).name === "string" && (node as any).name) ||
+      node.id;
+    const minItems = typeof node.minItems === "number" ? node.minItems : 0;
+    const maxItems = typeof node.maxItems === "number" ? node.maxItems : undefined;
+
+    const { fields: items, append, remove } = useFieldArray({
+      control: methods.control,
+      name,
+    });
+
+    const handleAdd = () => {
+      if (typeof maxItems === "number" && items.length >= maxItems) return;
+      append({});
+    };
+
+    const allowRemove = items.length > minItems;
+
+    return (
+      <section className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+        {(node.title || node.description) && (
+          <header className="space-y-1">
+            {node.title ? (
+              <h3 className="text-base font-semibold text-slate-800 dark:text-slate-100">{node.title}</h3>
+            ) : null}
+            {node.description ? (
+              <p className="text-sm text-slate-500 dark:text-slate-400">{node.description}</p>
+            ) : null}
+          </header>
+        )}
+        <div className="space-y-4">
+          {items.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-slate-300/80 p-4 text-xs text-slate-500 dark:border-slate-600/70 dark:text-slate-400">
+              Todavía no agregaste elementos.
+            </div>
+          ) : (
+            items.map((item, index) => (
+              <div
+                key={item.id ?? `${name}-${index}`}
+                className="space-y-4 rounded-lg border border-slate-200 bg-slate-50/60 p-4 dark:border-slate-700 dark:bg-slate-900/60"
+              >
+                {asArray(node.children).map((row, rowIndex) => (
+                  <Fragment key={(row as any)?.id ?? `${node.id}-row-${index}-${rowIndex}`}>
+                    {renderRow(row, [...repeaterStack, String(index)])}
+                  </Fragment>
+                ))}
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => remove(index)}
+                    disabled={!allowRemove}
+                    className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500/70 dark:text-red-200 dark:hover:bg-red-900/40"
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={typeof maxItems === "number" && items.length >= maxItems}
+            className="rounded-md border border-slate-300 px-3 py-1 text-xs text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            Agregar ítem
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const renderChild = (
+    child: LayoutChildNode,
+    withinColumn = false,
+    repeaterStack: string[] = [],
+  ): JSX.Element | null => {
     if (!child) return null;
     if ((child as LayoutSectionNode).type === "section") {
-      return renderSection(child as LayoutSectionNode);
+      return renderSection(child as LayoutSectionNode, repeaterStack);
     }
     if ((child as LayoutRowNode).type === "row") {
-      return renderRow(child as LayoutRowNode);
+      return renderRow(child as LayoutRowNode, repeaterStack);
+    }
+    if ((child as LayoutTabsNode).type === "tabs") {
+      return (
+        <TabsNodeRenderer
+          key={(child as LayoutTabsNode).id}
+          node={child as LayoutTabsNode}
+          repeaterStack={repeaterStack}
+        />
+      );
+    }
+    if ((child as LayoutRepeaterNode).type === "repeater") {
+      return (
+        <RepeaterNodeRenderer
+          key={(child as LayoutRepeaterNode).id}
+          node={child as LayoutRepeaterNode}
+          repeaterStack={repeaterStack}
+        />
+      );
     }
     if ((child as LayoutFieldNode).type === "field") {
-      return renderField(child as LayoutFieldNode, withinColumn);
+      return renderField(child as LayoutFieldNode, withinColumn, repeaterStack);
     }
     return null;
   };
 
-  const renderColumn = (column: LayoutColumnNode, index = 0): JSX.Element => {
+  const renderColumn = (
+    column: LayoutColumnNode,
+    index = 0,
+    repeaterStack: string[] = [],
+  ): JSX.Element => {
     const spanClass = colSpanClass(column.span);
     const key = column.id ?? `column-${index}`;
     return (
-      <div key={key} className={clsx(spanClass, "space-y-4")}> 
+      <div key={key} className={clsx(spanClass, "space-y-4")}>
         {asArray(column.children).map((child, childIndex) => (
           <Fragment key={(child as any)?.id ?? `${key}-child-${childIndex}`}>
-            {renderChild(child, true)}
+            {renderChild(child, true, repeaterStack)}
           </Fragment>
         ))}
       </div>
     );
   };
 
-  const renderRow = (row: LayoutRowNode): JSX.Element => {
+  const renderRow = (row: LayoutRowNode, repeaterStack: string[] = []): JSX.Element => {
     const columns = asArray(row.columns);
     const gutter = typeof row.gutter === "number" ? row.gutter : 16;
     return (
@@ -260,17 +504,20 @@ export default function DynamicFormRenderer({
         style={{ columnGap: `${gutter}px`, rowGap: `${gutter}px` }}
       >
         {columns.length > 0
-          ? columns.map((column, columnIndex) => renderColumn(column, columnIndex))
+          ? columns.map((column, columnIndex) => renderColumn(column, columnIndex, repeaterStack))
           : asArray((row as any).children).map((child, index) => (
               <Fragment key={(child as any)?.id ?? `${row.id}-field-${index}`}>
-                {renderField(child as LayoutFieldNode)}
+                {renderField(child as LayoutFieldNode, false, repeaterStack)}
               </Fragment>
             ))}
       </div>
     );
   };
 
-  const renderSection = (section: LayoutSectionNode): JSX.Element => {
+  const renderSection = (
+    section: LayoutSectionNode,
+    repeaterStack: string[] = [],
+  ): JSX.Element => {
     const rows = asArray(section.children);
     return (
       <section
@@ -288,23 +535,39 @@ export default function DynamicFormRenderer({
           </header>
         )}
         <div className="space-y-4">
-          {rows.map((row) => renderRow(row))}
+          {rows.map((row) => renderRow(row, repeaterStack))}
         </div>
       </section>
     );
   };
 
-  const renderNode = (node: LayoutNode): JSX.Element | null => {
+  const renderNode = (node: LayoutNode, repeaterStack: string[] = []): JSX.Element | null => {
     if (!node) return null;
     switch (node.type) {
       case "section":
-        return renderSection(node as LayoutSectionNode);
+        return renderSection(node as LayoutSectionNode, repeaterStack);
       case "row":
-        return renderRow(node as LayoutRowNode);
+        return renderRow(node as LayoutRowNode, repeaterStack);
       case "column":
-        return renderColumn(node as LayoutColumnNode);
+        return renderColumn(node as LayoutColumnNode, 0, repeaterStack);
       case "field":
-        return renderField(node as LayoutFieldNode);
+        return renderField(node as LayoutFieldNode, false, repeaterStack);
+      case "tabs":
+        return (
+          <TabsNodeRenderer
+            key={node.id}
+            node={node as LayoutTabsNode}
+            repeaterStack={repeaterStack}
+          />
+        );
+      case "repeater":
+        return (
+          <RepeaterNodeRenderer
+            key={node.id}
+            node={node as LayoutRepeaterNode}
+            repeaterStack={repeaterStack}
+          />
+        );
       default:
         return null;
     }
@@ -327,7 +590,7 @@ export default function DynamicFormRenderer({
       >
         {asArray(layout.nodes).map((node, index) => (
           <Fragment key={(node as any)?.id ?? `node-${index}`}>
-            {renderNode(node as LayoutNode)}
+            {renderNode(node as LayoutNode, [])}
           </Fragment>
         ))}
 

--- a/frontend/src/lib/forms/types.ts
+++ b/frontend/src/lib/forms/types.ts
@@ -187,13 +187,47 @@ export interface LayoutSectionNode {
   children: LayoutRowNode[];
 }
 
-export type LayoutChildNode = LayoutRowNode | LayoutFieldNode | LayoutSectionNode;
+export interface LayoutTabNode {
+  id: string;
+  type: "tab";
+  title?: string;
+  children?: LayoutRowNode[];
+}
+
+export interface LayoutTabsNode {
+  id: string;
+  type: "tabs";
+  title?: string;
+  description?: string;
+  tabs: Array<{ id: string; title?: string }>;
+  tabsChildren?: Record<string, LayoutChildNode[]>;
+}
+
+export interface LayoutRepeaterNode {
+  id: string;
+  type: "repeater";
+  title?: string;
+  description?: string;
+  fieldKey?: string;
+  minItems?: number;
+  maxItems?: number;
+  children?: LayoutRowNode[];
+}
+
+export type LayoutChildNode =
+  | LayoutRowNode
+  | LayoutFieldNode
+  | LayoutSectionNode
+  | LayoutTabsNode
+  | LayoutRepeaterNode;
 
 export type LayoutNode =
   | LayoutSectionNode
   | LayoutRowNode
   | LayoutColumnNode
-  | LayoutFieldNode;
+  | LayoutFieldNode
+  | LayoutTabsNode
+  | LayoutRepeaterNode;
 
 export interface FormLayout {
   version: number;


### PR DESCRIPTION
## Summary
* add layout node definitions for tabs and repeater containers
* extend the zod schema builder to traverse tab children and array items
* render tabs and repeater items in the dynamic form runtime and generic node renderer
* include tab and repeater nodes when extracting schema field metadata

## Testing
* ⚠️ `npm run lint` *(interactive eslint setup prompt blocked execution)*
* ⚠️ `npm run test` *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c89d8b43ec832da2482dc6df9aa4f5