### PR TITLE
Improve builder accessibility and keyboard interactions

### DIFF
--- a/frontend/src/app/(private)/plantillas/editor/[id]/_components/FieldDraggable.tsx
+++ b/frontend/src/app/(private)/plantillas/editor/[id]/_components/FieldDraggable.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import {
+  ComponentPropsWithoutRef,
   forwardRef,
   type ForwardedRef,
   type ReactNode,
   useCallback,
+  useId,
 } from "react";
 import type {
   DraggableAttributes,
@@ -13,7 +15,15 @@ import type {
 import { GripVertical, SquareMousePointer, Trash2 } from "lucide-react";
 import clsx from "clsx";
 
-interface FieldDraggableProps {
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface FieldDraggableProps
+  extends Omit<ComponentPropsWithoutRef<"div">, "onSelect"> {
   label: string;
   description?: string;
   icon?: ReactNode;
@@ -50,6 +60,7 @@ const FieldDraggable = forwardRef<HTMLDivElement, FieldDraggableProps>(
       onSelect,
       isSelected = false,
       className,
+      ...restProps
     },
     forwardedRef,
   ) {
@@ -62,10 +73,15 @@ const FieldDraggable = forwardRef<HTMLDivElement, FieldDraggableProps>(
       [setActivatorNodeRef, variant],
     );
 
+    const generatedId = useId();
+    const labelId = `${generatedId}-label`;
+    const descriptionId = description ? `${generatedId}-description` : undefined;
+
     const baseClass = clsx(
+      "outline-none transition focus:outline-none",
       variant === "palette"
-        ? "group flex cursor-grab flex-col gap-2 rounded-lg border border-dashed border-slate-300 bg-white/80 p-3 text-left text-sm text-slate-600 transition hover:border-slate-400 hover:bg-white dark:border-slate-600 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:bg-slate-900"
-        : "flex h-full flex-col gap-3 rounded-lg border bg-white p-3 text-left text-sm text-slate-600 shadow-sm transition dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200",
+        ? "group flex cursor-grab flex-col gap-2 rounded-lg border border-dashed border-slate-300 bg-white/80 p-3 text-left text-sm text-slate-600 hover:border-slate-400 hover:bg-white focus-visible:border-indigo-400 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-600 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:bg-slate-900 dark:focus-visible:ring-offset-slate-900"
+        : "flex h-full flex-col gap-3 rounded-lg border bg-white p-3 text-left text-sm text-slate-600 shadow-sm focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200 dark:focus-visible:ring-offset-slate-900",
       variant === "canvas" && isSelected
         ? "border-indigo-500 shadow-[0_0_0_1px_rgba(79,70,229,0.25)] dark:border-indigo-400"
         : null,
@@ -75,82 +91,160 @@ const FieldDraggable = forwardRef<HTMLDivElement, FieldDraggableProps>(
       className,
     );
 
-    const paletteDragProps =
-      variant === "palette"
-        ? { ...(dragAttributes ?? {}), ...(dragListeners ?? {}) }
-        : {};
+    const finalProps: Record<string, unknown> = { ...restProps };
+    const roleProp = finalProps.role as FieldDraggableProps["role"] | undefined;
+    if (roleProp != null) {
+      delete finalProps.role;
+    }
+    const tabIndexProp = finalProps.tabIndex as FieldDraggableProps["tabIndex"] | undefined;
+    if (tabIndexProp != null) {
+      delete finalProps.tabIndex;
+    }
+    const ariaDescribedByProp = finalProps["aria-describedby"] as string | undefined;
+    if (ariaDescribedByProp != null) {
+      delete finalProps["aria-describedby"];
+    }
+    const ariaLabelledByProp = finalProps["aria-labelledby"] as string | undefined;
+    if (ariaLabelledByProp != null) {
+      delete finalProps["aria-labelledby"];
+    }
+    const ariaSelectedProp = finalProps["aria-selected"] as boolean | undefined;
+    if (ariaSelectedProp != null) {
+      delete finalProps["aria-selected"];
+    }
+    const ariaRoleDescriptionProp = finalProps["aria-roledescription"] as
+      | string
+      | undefined;
+    if (ariaRoleDescriptionProp != null) {
+      delete finalProps["aria-roledescription"];
+    }
+
+    const mergedAriaLabelledBy =
+      [ariaLabelledByProp, labelId].filter(Boolean).join(" ") || undefined;
+    const mergedAriaDescribedBy =
+      [ariaDescribedByProp, descriptionId].filter(Boolean).join(" ") || undefined;
+    const resolvedRole = roleProp ?? (variant === "palette" ? "option" : "group");
+    const resolvedTabIndex = tabIndexProp ?? 0;
+    const resolvedAriaSelected =
+      ariaSelectedProp ?? (variant === "canvas" ? isSelected : undefined);
+    const resolvedAriaRoleDescription =
+      ariaRoleDescriptionProp ?? "Elemento arrastrable";
+
+    const {
+      role: _ignoredRole,
+      tabIndex: _ignoredTabIndex,
+      "aria-roledescription": _ignoredAriaRoleDescription,
+      ...draggableAttributes
+    } = dragAttributes ?? {};
+
+    const rootDraggableAttributes =
+      variant === "palette" ? draggableAttributes : undefined;
+    const rootDragListeners =
+      variant === "palette" ? dragListeners : undefined;
 
     return (
-      <div
-        ref={(node) => {
-          assignRef(forwardedRef, node);
-          if (variant === "palette") {
-            setActivatorNodeRef?.(node);
-          }
-        }}
-        className={baseClass}
-        {...paletteDragProps}
-      >
-        {variant === "canvas" ? (
-          <div className="flex items-center justify-between text-xs text-slate-400">
-            <button
-              type="button"
-              ref={handleMoveRef}
-              className="flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-slate-400 transition hover:border-slate-200 hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:hover:border-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-100"
-              aria-label="Mover elemento"
-              {...(dragAttributes ?? {})}
-              {...(dragListeners ?? {})}
-            >
-              <GripVertical className="h-4 w-4" />
-            </button>
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={onSelect}
-                disabled={!onSelect}
-                className={clsx(
-                  "flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-slate-400 transition hover:border-slate-200 hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:hover:border-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-100",
-                  isSelected ? "text-indigo-500 dark:text-indigo-400" : null,
-                  !onSelect ? "cursor-not-allowed opacity-50" : null,
-                )}
-                aria-label="Seleccionar elemento"
-              >
-                <SquareMousePointer className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={onDelete}
-                disabled={!onDelete}
-                className={clsx(
-                  "flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-slate-400 transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 dark:hover:border-red-700 dark:hover:bg-red-950/50 dark:hover:text-red-300",
-                  !onDelete ? "cursor-not-allowed opacity-50" : null,
-                )}
-                aria-label="Eliminar elemento"
-              >
-                <Trash2 className="h-4 w-4" />
-              </button>
+      <TooltipProvider delayDuration={200} disableHoverableContent>
+        <div
+          {...(finalProps as ComponentPropsWithoutRef<"div">)}
+          ref={(node) => {
+            assignRef(forwardedRef, node);
+            if (variant === "palette") {
+              setActivatorNodeRef?.(node);
+            }
+          }}
+          role={resolvedRole}
+          tabIndex={resolvedTabIndex}
+          aria-labelledby={mergedAriaLabelledBy}
+          aria-describedby={mergedAriaDescribedBy}
+          aria-selected={resolvedAriaSelected}
+          aria-roledescription={resolvedAriaRoleDescription}
+          className={baseClass}
+          {...(rootDraggableAttributes ?? {})}
+          {...(rootDragListeners ?? {})}
+        >
+          {variant === "canvas" ? (
+            <div className="flex items-center justify-between text-xs text-slate-400">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    ref={handleMoveRef}
+                    className="flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-slate-400 transition hover:border-slate-200 hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:hover:border-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-100 dark:focus-visible:ring-offset-slate-900"
+                    aria-label="Mover elemento"
+                    {...(draggableAttributes as DraggableAttributes)}
+                    {...(dragListeners ?? {})}
+                  >
+                    <GripVertical className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Mover elemento</TooltipContent>
+              </Tooltip>
+              <div className="flex items-center gap-1">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={onSelect}
+                      disabled={!onSelect}
+                      className={clsx(
+                        "flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-slate-400 transition hover:border-slate-200 hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:hover:border-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-100 dark:focus-visible:ring-offset-slate-900",
+                        isSelected ? "text-indigo-500 dark:text-indigo-400" : null,
+                        !onSelect ? "cursor-not-allowed opacity-50" : null,
+                      )}
+                      aria-label="Seleccionar elemento"
+                    >
+                      <SquareMousePointer className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Seleccionar para configurar</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={onDelete}
+                      disabled={!onDelete}
+                      className={clsx(
+                        "flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-slate-400 transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:hover:border-red-700 dark:hover:bg-red-950/50 dark:hover:text-red-300 dark:focus-visible:ring-offset-slate-900",
+                        !onDelete ? "cursor-not-allowed opacity-50" : null,
+                      )}
+                      aria-label="Eliminar elemento"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Eliminar elemento</TooltipContent>
+                </Tooltip>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex items-start gap-2">
+            {icon ? (
+              <span className="mt-0.5 text-slate-400 dark:text-slate-500">{icon}</span>
+            ) : null}
+            <div className="flex flex-col gap-1">
+              <span id={labelId} className="font-medium text-slate-700 dark:text-slate-100">
+                {label}
+              </span>
+              {description ? (
+                <span
+                  id={descriptionId}
+                  className="text-xs text-slate-500 dark:text-slate-400"
+                >
+                  {description}
+                </span>
+              ) : null}
             </div>
           </div>
-        ) : null}
 
-        <div className="flex items-start gap-2">
-          {icon ? (
-            <span className="mt-0.5 text-slate-400 dark:text-slate-500">{icon}</span>
+          {variant === "palette" ? (
+            <span className="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Arrastrar y soltar
+            </span>
           ) : null}
-          <div className="flex flex-col gap-1">
-            <span className="font-medium text-slate-700 dark:text-slate-100">{label}</span>
-            {description ? (
-              <span className="text-xs text-slate-500 dark:text-slate-400">{description}</span>
-            ) : null}
-          </div>
         </div>
-
-        {variant === "palette" ? (
-          <span className="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">
-            Arrastrar y soltar
-          </span>
-        ) : null}
-      </div>
+      </TooltipProvider>
     );
   },
 );

--- a/frontend/src/app/(private)/plantillas/editor/[id]/_components/Palette.tsx
+++ b/frontend/src/app/(private)/plantillas/editor/[id]/_components/Palette.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type KeyboardEvent,
+} from "react";
 import { useDraggable } from "@dnd-kit/core";
 import clsx from "clsx";
 
 import builderConfig from "../builder.config";
 import FieldDraggable from "./FieldDraggable";
-import type { CanvasPaletteItem } from "./CanvasGrid";
+import {
+  useCanvasGridContext,
+  type CanvasPaletteItem,
+} from "./CanvasGrid";
 
 interface PaletteCategory {
   id: string;
@@ -42,15 +53,35 @@ function buildCategories(): PaletteCategory[] {
   return categories;
 }
 
-function PaletteItem({ component }: { component: CanvasPaletteItem }) {
+interface PaletteItemProps {
+  component: CanvasPaletteItem;
+  isActive: boolean;
+  onFocus: () => void;
+  onBlur: (event: FocusEvent<HTMLDivElement>) => void;
+}
+
+function PaletteItem({ component, isActive, onFocus, onBlur }: PaletteItemProps) {
+  const { addNodeFromPalette } = useCanvasGridContext();
   const { attributes, listeners, setActivatorNodeRef, setNodeRef, isDragging } =
     useDraggable({
       id: `palette-${component.key}`,
       data: { type: "palette", component },
     });
 
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.defaultPrevented) return;
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        addNodeFromPalette(component);
+      }
+    },
+    [addNodeFromPalette, component],
+  );
+
   return (
     <FieldDraggable
+      id={`palette-${component.key}`}
       ref={setNodeRef}
       label={component.label}
       description={component.description}
@@ -59,16 +90,91 @@ function PaletteItem({ component }: { component: CanvasPaletteItem }) {
       dragListeners={listeners}
       setActivatorNodeRef={setActivatorNodeRef}
       className={clsx(isDragging ? "opacity-60" : undefined)}
+      onKeyDown={handleKeyDown}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      aria-selected={isActive}
+      aria-grabbed={isDragging}
+      data-palette-option="true"
     />
   );
 }
 
 export default function Palette() {
-  const categories = buildCategories();
+  const categories = useMemo(() => buildCategories(), []);
   const isEmpty = categories.length === 0;
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [activeOptionKey, setActiveOptionKey] = useState<string | null>(null);
+
+  const handleListKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    const { key } = event;
+    if (
+      key !== "ArrowDown" &&
+      key !== "ArrowUp" &&
+      key !== "ArrowLeft" &&
+      key !== "ArrowRight" &&
+      key !== "Home" &&
+      key !== "End"
+    ) {
+      return;
+    }
+
+    const container = listRef.current;
+    if (!container) return;
+    if (!container.contains(event.target as Node)) return;
+
+    const options = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-palette-option=\"true\"]"),
+    );
+    if (options.length === 0) return;
+
+    const activeElement = document.activeElement as HTMLElement | null;
+    const currentIndex = activeElement ? options.indexOf(activeElement) : -1;
+    let nextIndex = currentIndex;
+
+    if (key === "Home") {
+      nextIndex = 0;
+    } else if (key === "End") {
+      nextIndex = options.length - 1;
+    } else if (key === "ArrowDown" || key === "ArrowRight") {
+      nextIndex = currentIndex < options.length - 1 ? currentIndex + 1 : 0;
+    } else if (key === "ArrowUp" || key === "ArrowLeft") {
+      nextIndex = currentIndex > 0 ? currentIndex - 1 : options.length - 1;
+    }
+
+    if (nextIndex !== currentIndex && options[nextIndex]) {
+      event.preventDefault();
+      options[nextIndex].focus();
+    }
+  }, []);
+
+  const handleOptionFocus = useCallback(
+    (key: string) => {
+      setActiveOptionKey(key);
+    },
+    [setActiveOptionKey],
+  );
+
+  const handleOptionBlur = useCallback(
+    (event: FocusEvent<HTMLDivElement>) => {
+      const container = listRef.current;
+      if (!container) {
+        setActiveOptionKey(null);
+        return;
+      }
+      const nextTarget = event.relatedTarget as HTMLElement | null;
+      if (!nextTarget || !container.contains(nextTarget)) {
+        setActiveOptionKey(null);
+      }
+    },
+    [setActiveOptionKey],
+  );
 
   return (
-    <aside className="flex h-full min-h-0 flex-col gap-4 overflow-hidden rounded-xl border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
+    <aside
+      className="flex h-full min-h-0 flex-col gap-4 overflow-hidden rounded-xl border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300"
+      aria-label="Paleta de componentes"
+    >
       <div>
         <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
           Componentes disponibles
@@ -78,26 +184,50 @@ export default function Palette() {
         </p>
       </div>
 
-      <div className="flex-1 space-y-4 overflow-y-auto pr-1">
+      <div
+        ref={listRef}
+        role="listbox"
+        aria-label="Componentes disponibles"
+        aria-orientation="vertical"
+        className="flex-1 space-y-4 overflow-y-auto pr-1"
+        onKeyDown={handleListKeyDown}
+      >
         {isEmpty ? (
           <div className="rounded-lg border border-dashed border-slate-300 bg-white/70 p-4 text-xs text-slate-500 dark:border-slate-600 dark:bg-slate-900/50 dark:text-slate-400">
             Todavía no hay componentes configurados.
           </div>
         ) : (
-          categories.map((category) => (
-            <section key={category.id} className="space-y-2">
-              <header>
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  {category.label}
-                </h3>
-              </header>
-              <div className="space-y-2">
-                {category.items.map((component) => (
-                  <PaletteItem key={component.key} component={component} />
-                ))}
-              </div>
-            </section>
-          ))
+          categories.map((category) => {
+            const headerId = `palette-category-${category.id}`;
+            return (
+              <section
+                key={category.id}
+                className="space-y-2"
+                role="group"
+                aria-labelledby={headerId}
+              >
+                <header>
+                  <h3
+                    id={headerId}
+                    className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+                  >
+                    {category.label}
+                  </h3>
+                </header>
+                <div className="space-y-2">
+                  {category.items.map((component) => (
+                    <PaletteItem
+                      key={component.key}
+                      component={component}
+                      isActive={activeOptionKey === component.key}
+                      onFocus={() => handleOptionFocus(component.key)}
+                      onBlur={handleOptionBlur}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })
         )}
       </div>
     </aside>

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+  forwardRef,
+  type HTMLAttributes,
+  type MutableRefObject,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type SyntheticEvent,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+interface TooltipContextValue {
+  id: string;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const TooltipContext = createContext<TooltipContextValue | null>(null);
+
+function useTooltipContext(): TooltipContextValue {
+  const context = useContext(TooltipContext);
+  if (!context) {
+    throw new Error("Tooltip components must be used within a Tooltip");
+  }
+  return context;
+}
+
+export interface TooltipProviderProps {
+  children: ReactNode;
+  delayDuration?: number;
+  disableHoverableContent?: boolean;
+}
+
+function TooltipProvider({ children }: TooltipProviderProps) {
+  return <>{children}</>;
+}
+
+function mergeRefs<T>(...refs: Array<Ref<T> | undefined>) {
+  return (value: T) => {
+    refs.forEach((ref) => {
+      if (!ref) return;
+      if (typeof ref === "function") {
+        ref(value);
+      } else {
+        (ref as MutableRefObject<T | null>).current = value;
+      }
+    });
+  };
+}
+
+function composeEventHandlers<EventType extends SyntheticEvent>(
+  originalHandler: ((event: EventType) => void) | undefined,
+  nextHandler: (event: EventType) => void,
+) {
+  return (event: EventType) => {
+    originalHandler?.(event);
+    if (!event.defaultPrevented) {
+      nextHandler(event);
+    }
+  };
+}
+
+interface TooltipProps {
+  children: ReactNode;
+}
+
+function Tooltip({ children }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+  const value = useMemo<TooltipContextValue>(
+    () => ({ id, open, setOpen }),
+    [id, open],
+  );
+
+  return (
+    <TooltipContext.Provider value={value}>
+      <span className="relative inline-flex">{children}</span>
+    </TooltipContext.Provider>
+  );
+}
+
+interface TooltipTriggerProps extends HTMLAttributes<HTMLElement> {
+  asChild?: boolean;
+  children: ReactElement;
+}
+
+const TooltipTrigger = forwardRef<HTMLElement, TooltipTriggerProps>(
+  ({ asChild = false, children, ...props }, forwardedRef) => {
+    const context = useTooltipContext();
+
+    const handleOpen = () => context.setOpen(true);
+    const handleClose = () => context.setOpen(false);
+
+    const describedBy = context.open ? context.id : undefined;
+
+    if (asChild) {
+      const child = Children.only(children);
+      if (!isValidElement(child)) {
+        throw new Error("TooltipTrigger with asChild expects a single React element child.");
+      }
+
+      const existingDescribedBy =
+        (child.props as Record<string, unknown>)["aria-describedby"] || undefined;
+      const composedProps = {
+        ...child.props,
+        ...props,
+        onMouseEnter: composeEventHandlers(child.props.onMouseEnter, handleOpen),
+        onMouseLeave: composeEventHandlers(child.props.onMouseLeave, handleClose),
+        onFocus: composeEventHandlers(child.props.onFocus, handleOpen),
+        onBlur: composeEventHandlers(child.props.onBlur, handleClose),
+        ref: mergeRefs((child as any).ref, forwardedRef),
+        "aria-describedby": [existingDescribedBy, describedBy]
+          .filter(Boolean)
+          .join(" ") || undefined,
+      };
+
+      return cloneElement(child, composedProps);
+    }
+
+    const existingDescribedBy =
+      (children.props as Record<string, unknown>)["aria-describedby"] || undefined;
+
+    return cloneElement(children, {
+      ...props,
+      ref: mergeRefs((children as any).ref, forwardedRef),
+      onMouseEnter: composeEventHandlers(children.props.onMouseEnter, handleOpen),
+      onMouseLeave: composeEventHandlers(children.props.onMouseLeave, handleClose),
+      onFocus: composeEventHandlers(children.props.onFocus, handleOpen),
+      onBlur: composeEventHandlers(children.props.onBlur, handleClose),
+      "aria-describedby": [existingDescribedBy, describedBy]
+        .filter(Boolean)
+        .join(" ") || undefined,
+    });
+  },
+);
+TooltipTrigger.displayName = "TooltipTrigger";
+
+interface TooltipContentProps extends HTMLAttributes<HTMLDivElement> {
+  side?: "top" | "bottom" | "left" | "right";
+  align?: "start" | "center" | "end";
+  sideOffset?: number;
+}
+
+const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(
+  (
+    {
+      className,
+      side = "top",
+      align = "center",
+      sideOffset = 6,
+      style,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const { id, open } = useTooltipContext();
+    if (!open) return null;
+
+    const offsetStyle: Record<string, number> = {};
+    if (side === "top") offsetStyle.marginBottom = sideOffset;
+    if (side === "bottom") offsetStyle.marginTop = sideOffset;
+    if (side === "left") offsetStyle.marginRight = sideOffset;
+    if (side === "right") offsetStyle.marginLeft = sideOffset;
+
+    const sideClass =
+      side === "bottom"
+        ? "top-full"
+        : side === "left"
+        ? "right-full"
+        : side === "right"
+        ? "left-full"
+        : "bottom-full";
+
+    const alignClass = (() => {
+      if (side === "left" || side === "right") {
+        if (align === "start") return "top-0";
+        if (align === "end") return "bottom-0";
+        return "top-1/2 -translate-y-1/2";
+      }
+      if (align === "start") return "left-0";
+      if (align === "end") return "right-0";
+      return "left-1/2 -translate-x-1/2";
+    })();
+
+    return (
+      <div
+        ref={ref}
+        id={id}
+        role="tooltip"
+        className={cn(
+          "pointer-events-none absolute z-50 min-w-max rounded-md border border-slate-200 bg-slate-900 px-3 py-1.5 text-xs text-slate-50 shadow-md",
+          sideClass,
+          alignClass,
+          className,
+        )}
+        style={{ ...style, ...offsetStyle }}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+TooltipContent.displayName = "TooltipContent";
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION
## Summary
- add accessible tooltip primitives and update draggable controls with focus-visible styling and tooltips
- treat palette as a keyboard-navigable listbox with ARIA roles and support adding components via keyboard
- expose keyboard movement helpers for canvas items, including preview ghost details and column span badge while dragging

## Testing
- `npm run lint` *(fails: command requires interactive setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c896f3e554832d9b60c6b983212823