### PR TITLE
Document frontend module and add DynamicForm integration tests

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,92 @@
-Placeholder frontend directory for Next.js project.
+# Frontend de formularios
 
-When running inside Docker, configure the API URL to use the backend service at `http://backend:8000`.
+Este paquete contiene la aplicación Next.js encargada del constructor de plantillas y del runtime de formularios para legajos. Incluye el editor visual, los servicios para persistir plantillas y el componente `DynamicForm` para renderizar esquemas guardados.
+
+## Scripts útiles
+
+```bash
+npm install        # instala dependencias
+npm run dev        # levanta el entorno de desarrollo
+npm run lint       # ejecuta el lint de Next.js
+npm run build      # genera el build de producción
+npm test           # corre la suite de Vitest
+```
+
+## Flujo de trabajo del editor
+
+### 1. Acceder al constructor
+- Ingresá a `/plantillas` para listar las plantillas disponibles. Desde el botón `+ Crear plantilla` se navega a `/plantillas/crear`, que monta el componente `<Builder />` con el constructor completo.【F:frontend/src/components/plantillas/PlantillasPage.tsx†L36-L73】【F:frontend/src/app/plantillas/crear/page.tsx†L1-L9】
+- Para editar una existente, el botón `Editar` navega a `/plantillas/editar/[id]`, que carga la plantilla desde la API antes de inyectarla en `<Builder />`.【F:frontend/src/components/plantillas/PlantillasPage.tsx†L208-L229】【F:frontend/src/app/plantillas/editar/[id]/page.tsx†L1-L10】
+
+### 2. Construir secciones y campos
+- El constructor inicializa el store con la plantilla recibida, agrega una sección vacía en caso de ser necesario y sincroniza la pestaña visual. Además registra manejadores globales para abrir la modal de componentes y la de propiedades.【F:frontend/src/components/form/builder/Builder.tsx†L1-L89】
+- El lienzo central permite crear secciones, arrastrarlas y cambiar sus campos mediante `dnd-kit`. El botón `+ Agregar sección` dispara la creación y abre automáticamente la selección de componentes.【F:frontend/src/components/form/builder/Canvas.tsx†L19-L79】
+- Cada sección (`SortableSection`) ofrece cambiar el título, modo de disposición (lista o grilla), duplicarla o eliminarla. Dentro se renderizan los campos arrastrables (`SortableField`), con acciones de duplicar, editar o eliminar.【F:frontend/src/components/form/builder/dnd/SortableSection.tsx†L1-L99】【F:frontend/src/components/form/builder/dnd/SortableField.tsx†L1-L40】
+- El botón flotante `+` abre la paleta de componentes. Desde la modal podés insertar campos básicos, avanzados y bloques de UI; al elegir uno se agrega en la sección seleccionada y se abre la modal de propiedades.【F:frontend/src/components/form/builder/FloatingToolbar.tsx†L1-L10】【F:frontend/src/components/form/builder/ComponentsModal.tsx†L1-L63】
+
+### 3. Editar propiedades de los campos
+- Al hacer clic en `Editar` se abre `FieldPropertiesModal`, que clona el nodo seleccionado y muestra controles comunes (etiqueta, key, flags de obligatoriedad y visibilidad) más ajustes específicos por tipo: placeholders y regex para textos, rangos numéricos, opciones para selects, límites de archivos, fuentes de sumas, etc.【F:frontend/src/components/form/builder/FieldPropertiesModal.tsx†L1-L162】
+- Los campos de suma muestran las claves numéricas disponibles mediante `collectKeysByType` para garantizar consistencia, y los grupos (`group`) permiten editar nodos anidados desde la misma modal.【F:frontend/src/components/form/builder/FieldPropertiesModal.tsx†L105-L160】【F:frontend/src/lib/store/usePlantillaBuilderStore.ts†L188-L268】
+
+### 4. Configuración visual
+- La pestaña “Visual” permite ajustar encabezado y contadores del legajo (variante, textos y KPIs). Cada cambio persiste en el store `useTemplateStore` para guardarse junto con el esquema.【F:frontend/src/components/form/builder/Builder.tsx†L14-L70】【F:frontend/src/components/plantillas/VisualTab.tsx†L1-L73】
+
+### 5. Guardar la plantilla
+- El encabezado (`BuilderHeader`) incluye el campo “Nombre de la plantilla” y el botón `Guardar`. Antes de persistir ejecuta `validateAll()` del store, que verifica secciones no vacías, claves únicas y configuración coherente (por ejemplo que las sumas apunten a números). Si hay errores se muestra un `alert` con el detalle.【F:frontend/src/components/form/builder/BuilderHeader.tsx†L1-L61】【F:frontend/src/lib/store/usePlantillaBuilderStore.ts†L212-L256】
+- En caso exitoso serializa la plantilla con `serializeTemplateSchema`, envía los datos a `PlantillasService.savePlantilla` y actualiza la configuración visual. Luego invalida las queries de React Query y redirige nuevamente a `/plantillas`.【F:frontend/src/components/form/builder/BuilderHeader.tsx†L62-L105】【F:frontend/src/lib/serializeTemplate.ts†L1-L48】【F:frontend/src/lib/services/plantillas.ts†L31-L68】
+
+## Previsualización y runtime
+
+### Previsualizar una plantilla
+- Desde la lista de plantillas, el botón `Previsualizar` guarda el esquema en `localStorage` (clave `nodo.plantilla.preview`) y abre una nueva pestaña con `/plantillas/previsualizacion`.【F:frontend/src/components/plantillas/PlantillasPage.tsx†L209-L229】
+- Esa página cliente lee el esquema del almacenamiento local y lo renderiza con `DynamicForm`, permitiendo revisar el formulario sin persistir un legajo.【F:frontend/src/app/plantillas/previsualizacion/page.tsx†L1-L9】
+
+### Renderizado en producción
+- Para usar una plantilla en la creación de legajos, navegá a `/legajos/nuevo?formId=<id>`. La vista lista los registros existentes mediante React Query y ofrece el botón `Crear` para abrir `/legajos/nuevo/crear?formId=<id>`.【F:frontend/src/app/legajos/nuevo/page.tsx†L1-L41】
+- La pantalla de creación obtiene la plantilla, instancia `DynamicForm` y al enviar hace `POST /api/legajos` con la data. Tras un alta exitosa invalida la lista y vuelve a `/legajos/nuevo`.【F:frontend/src/app/legajos/nuevo/crear/_CreateView.tsx†L1-L54】
+- `DynamicForm` normaliza distintas estructuras (`sections`, `nodes`, `fields`), filtra los nodos de UI y genera un esquema de validación con Zod (`zodFromTemplate`). Si no hay campos muestra un estado vacío con un CTA hacia el constructor.【F:frontend/src/components/form/runtime/DynamicForm.tsx†L1-L56】【F:frontend/src/components/form/runtime/DynamicForm.tsx†L58-L86】
+- Cada nodo se resuelve mediante `DynamicNode`, que respeta condiciones de visibilidad y conecta el campo correcto (`text`, `number`, `select`, `date`, `document`, `sum`, `phone`, `cuit_razon_social`, `info`, `group`).【F:frontend/src/components/form/runtime/DynamicNode.tsx†L1-L44】
+
+### Reutilizar `DynamicForm`
+
+```tsx
+import DynamicForm from '@/components/form/runtime/DynamicForm';
+
+export default function Demo({ schema }) {
+  return (
+    <DynamicForm
+      schema={schema}
+      onSubmit={(values) => {
+        console.log('Valores validados', values);
+      }}
+    />
+  );
+}
+```
+
+- Pasá cualquier estructura que contenga `nodes`, `fields` o `sections`; el componente los unifica internamente y asegura validación con `react-hook-form` + Zod.【F:frontend/src/components/form/runtime/DynamicForm.tsx†L1-L44】【F:frontend/src/components/form/builder/zodFromTemplate.ts†L1-L94】
+
+## Componentes disponibles
+
+| Tipo | Descripción | Props clave |
+| --- | --- | --- |
+| `text` / `textarea` | Campo de texto corto o largo. | `label`, `key`, `placeholder`, `required`, `maxLength`, `pattern` (regex).【F:frontend/src/lib/form-builder/factory.ts†L32-L56】【F:frontend/src/components/form/builder/FieldPropertiesModal.tsx†L113-L132】 |
+| `number` | Entrada numérica con conversión automática. | `label`, `key`, `required`, `min`, `max`, `step`. Se expone como `<input type="number">`.【F:frontend/src/components/form/runtime/fields/NumberField.tsx†L1-L14】【F:frontend/src/components/form/builder/FieldPropertiesModal.tsx†L134-L148】 |
+| `date` | Selector de fecha nativo. | `label`, `key`, `required`, límites opcionales. |【F:frontend/src/components/form/runtime/fields/DateField.tsx†L1-L10】
+| `select` / `dropdown` | Lista desplegable de selección única. | `label`, `key`, `placeholder`, `options[{ value, label }]`, `required`.【F:frontend/src/components/form/runtime/fields/SelectField.tsx†L1-L23】【F:frontend/src/components/form/builder/FieldPropertiesModal.tsx†L150-L162】 |
+| `multiselect` | Selector múltiple (usa `<select multiple>`). | Igual a `select`, acepta varias opciones y puede limitar cantidad. |【F:frontend/src/components/form/runtime/fields/SelectField.tsx†L1-L13】
+| `select_with_filter` | Variante de selector que se trata igual que `select`, pero permite configurar filtros en backend. | Mismos props que `select`. |【F:frontend/src/components/form/runtime/DynamicNode.tsx†L29-L37】
+| `document` | Campo de archivos con validaciones de extensión/tamaño. | `label`, `key`, `accept`, `maxSizeMB`, `isNewFileFlag`. Renderiza `<input type="file">`.【F:frontend/src/components/form/runtime/fields/DocumentField.tsx†L1-L9】【F:frontend/src/lib/form-builder/factory.ts†L42-L45】 |
+| `sum` | Campo de sólo lectura que suma otras claves numéricas. | `label`, `key`, `sources[]`, `decimals`. Calcula el total en vivo mediante `useWatch`.【F:frontend/src/components/form/runtime/fields/SumField.tsx†L1-L15】【F:frontend/src/components/form/builder/FieldPropertiesModal.tsx†L162-L190】 |
+| `phone` | Entrada telefónica sin formato específico. | `label`, `key`, `required`. |【F:frontend/src/components/form/runtime/fields/PhoneField.tsx†L1-L9】
+| `cuit_razon_social` | Paquete de dos entradas (CUIT + Razón social) bajo la misma key. | `label`, `key`; genera subclaves `.cuit` y `.razon_social`.【F:frontend/src/components/form/runtime/fields/CuitRazonSocialField.tsx†L1-L10】 |
+| `info` | Bloque informativo con HTML embebido. | `label`, `html`. Se renderiza con `dangerouslySetInnerHTML`.【F:frontend/src/components/form/runtime/fields/InfoField.tsx†L1-L5】 |
+| `group` | Grupo iterativo que permite instancias múltiples de un subconjunto de campos. | `label`, `key`, `children[]`, `minItems`, `maxItems`. Usa `useFieldArray` para agregar/eliminar filas.【F:frontend/src/components/form/runtime/fields/GroupField.tsx†L1-L18】【F:frontend/src/lib/form-builder/factory.ts†L18-L24】 |
+
+### Bloques de UI
+Los siguientes elementos no generan datos, pero se pueden ubicar desde la modal de componentes para enriquecer la presentación del legajo: `ui:header`, `ui:kpi-grid`, `ui:divider`, `ui:banner`, `ui:summary-pinned`, `ui:attachments`, `ui:timeline`. Se instancian con valores por defecto y se diferencian por la propiedad `kind: "ui"`.【F:frontend/src/components/form/builder/ComponentsModal.tsx†L7-L40】【F:frontend/src/lib/form-builder/factory.ts†L58-L101】
+
+## Buenas prácticas
+- Mantené claves únicas y descriptivas; el store aporta `ensureUniqueKey` y las validaciones avisan duplicados antes de guardar.【F:frontend/src/lib/store/usePlantillaBuilderStore.ts†L180-L214】
+- Usá `Previsualizar` para validar estados intermedios sin necesidad de crear legajos de prueba.【F:frontend/src/components/plantillas/PlantillasPage.tsx†L209-L229】
+- Antes de publicar cambios corré `npm run lint`, `npm run build` y `npm test` para asegurar calidad del módulo.

--- a/frontend/src/components/form/runtime/DynamicForm.test.tsx
+++ b/frontend/src/components/form/runtime/DynamicForm.test.tsx
@@ -1,25 +1,91 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import DynamicForm from './DynamicForm';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
-const schema = { nodes: [ { type:'section', id:'s', title:'S1', children:[
+const sumSchema = { nodes: [ { type:'section', id:'s', title:'S1', children:[
   {type:'number', id:'n1', key:'n1', label:'N1'},
   {type:'number', id:'n2', key:'n2', label:'N2'},
   {type:'sum', id:'s1', key:'s1', label:'S', sources:['n1','n2']},
   {type:'text', id:'t1', key:'t1', label:'T1', condicionesOcultar:[{key:'n1', op:'eq', value:1}]}
 ]}]};
 
+const fieldsSchema = {
+  nodes: [
+    {
+      type: 'section',
+      id: 'sec-basic',
+      title: 'Datos básicos',
+      children: [
+        { type: 'text', id: 'txt', key: 'nombre', label: 'Nombre', required: true },
+        { type: 'number', id: 'num', key: 'edad', label: 'Edad', required: true },
+        {
+          type: 'select',
+          id: 'sel',
+          key: 'color',
+          label: 'Color favorito',
+          required: true,
+          placeholder: 'Elegí un color',
+          options: [
+            { value: 'rojo', label: 'Rojo' },
+            { value: 'azul', label: 'Azul' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 describe('DynamicForm', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('sum recalculates and hides fields', async () => {
     const onSubmit = () => {};
-    render(<DynamicForm schema={schema} onSubmit={onSubmit} />);
+    render(<DynamicForm schema={sumSchema} onSubmit={onSubmit} />);
     const n1 = screen.getByLabelText('N1') as HTMLInputElement;
     const n2 = screen.getByLabelText('N2') as HTMLInputElement;
-    await userEvent.type(n1, '1');
-    await userEvent.type(n2, '2');
+    fireEvent.change(n1, { target: { value: '1' } });
+    fireEvent.change(n2, { target: { value: '2' } });
     expect(screen.getByText('3')).toBeInTheDocument();
     // field hidden
     expect(screen.queryByLabelText('T1')).toBeNull();
+  });
+
+  it('renders text, number and select fields', () => {
+    const onSubmit = () => {};
+    render(<DynamicForm schema={fieldsSchema} onSubmit={onSubmit} />);
+
+    const textInput = screen.getByLabelText('Nombre');
+    const numberInput = screen.getByLabelText('Edad');
+    const selectInput = screen.getByLabelText('Color favorito');
+
+    expect(textInput).toBeInTheDocument();
+    expect(numberInput).toHaveAttribute('type', 'number');
+    expect(selectInput.tagName).toBe('SELECT');
+  });
+
+  it('calls onSubmit with form values when validation passes', async () => {
+    const onSubmit = vi.fn();
+    render(<DynamicForm schema={fieldsSchema} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Ada' } });
+    fireEvent.change(screen.getByLabelText('Edad'), { target: { value: '34' } });
+    fireEvent.change(screen.getByLabelText('Color favorito'), { target: { value: 'azul' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const [submitted] = onSubmit.mock.calls[0];
+    expect(submitted).toMatchObject({ nombre: 'Ada', edad: 34, color: 'azul' });
+  });
+
+  it('does not call submit handler when validation fails', async () => {
+    const onSubmit = vi.fn();
+    render(<DynamicForm schema={fieldsSchema} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/form/runtime/fields/CuitRazonSocialField.tsx
+++ b/frontend/src/components/form/runtime/fields/CuitRazonSocialField.tsx
@@ -1,10 +1,13 @@
+import { useId } from "react";
 import { useFormContext } from "react-hook-form";
 export default function CuitRazonSocialField({ field }:{field:any}) {
   const { register } = useFormContext();
+  const autoId = useId();
+  const baseId = field.key ?? field.id ?? autoId;
   return (
     <div className="flex flex-col space-y-2">
-      <div className="flex flex-col"><label className="mb-1">CUIT</label><input className="border rounded px-2 py-1" {...register(`${field.key}.cuit`)} /></div>
-      <div className="flex flex-col"><label className="mb-1">Razón Social</label><input className="border rounded px-2 py-1" {...register(`${field.key}.razon_social`)} /></div>
+      <div className="flex flex-col"><label className="mb-1" htmlFor={`${baseId}-cuit`}>CUIT</label><input id={`${baseId}-cuit`} className="border rounded px-2 py-1" {...register(`${field.key}.cuit`)} /></div>
+      <div className="flex flex-col"><label className="mb-1" htmlFor={`${baseId}-razon`}>Razón Social</label><input id={`${baseId}-razon`} className="border rounded px-2 py-1" {...register(`${field.key}.razon_social`)} /></div>
     </div>
   );
 }

--- a/frontend/src/components/form/runtime/fields/DateField.tsx
+++ b/frontend/src/components/form/runtime/fields/DateField.tsx
@@ -1,10 +1,13 @@
+import { useId } from "react";
 import { useFormContext } from "react-hook-form";
 export default function DateField({ field }:{field:any}) {
   const { register } = useFormContext();
+  const autoId = useId();
+  const id = field.key ?? field.id ?? autoId;
   return (
     <div className="flex flex-col">
-      <label className="mb-1">{field.label}</label>
-      <input type="date" className="border rounded px-2 py-1" {...register(field.key)} />
+      <label className="mb-1" htmlFor={id}>{field.label}</label>
+      <input type="date" id={id} className="border rounded px-2 py-1" {...register(field.key)} />
     </div>
   );
 }

--- a/frontend/src/components/form/runtime/fields/DocumentField.tsx
+++ b/frontend/src/components/form/runtime/fields/DocumentField.tsx
@@ -1,10 +1,13 @@
+import { useId } from "react";
 import { useFormContext } from "react-hook-form";
 export default function DocumentField({ field }:{field:any}) {
   const { register } = useFormContext();
+  const autoId = useId();
+  const id = field.key ?? field.id ?? autoId;
   return (
     <div className="flex flex-col">
-      <label className="mb-1">{field.label}</label>
-      <input type="file" className="border rounded px-2 py-1" {...register(field.key)} />
+      <label className="mb-1" htmlFor={id}>{field.label}</label>
+      <input type="file" id={id} className="border rounded px-2 py-1" {...register(field.key)} />
     </div>
   );
 }

--- a/frontend/src/components/form/runtime/fields/NumberField.tsx
+++ b/frontend/src/components/form/runtime/fields/NumberField.tsx
@@ -1,12 +1,16 @@
+import { useId } from "react";
 import { useFormContext } from "react-hook-form";
 export default function NumberField({ field }:{field:any}) {
   const { register } = useFormContext();
+  const autoId = useId();
+  const id = field.key ?? field.id ?? autoId;
   return (
     <div className="flex flex-col">
-      <label className="mb-1">{field.label}</label>
+      <label className="mb-1" htmlFor={id}>{field.label}</label>
       <input
         type="number"
         className="border rounded px-2 py-1"
+        id={id}
         {...register(field.key, { valueAsNumber: true })}
       />
     </div>

--- a/frontend/src/components/form/runtime/fields/PhoneField.tsx
+++ b/frontend/src/components/form/runtime/fields/PhoneField.tsx
@@ -1,10 +1,13 @@
+import { useId } from "react";
 import { useFormContext } from "react-hook-form";
 export default function PhoneField({ field }:{field:any}) {
   const { register } = useFormContext();
+  const autoId = useId();
+  const id = field.key ?? field.id ?? autoId;
   return (
     <div className="flex flex-col">
-      <label className="mb-1">{field.label}</label>
-      <input className="border rounded px-2 py-1" {...register(field.key)} />
+      <label className="mb-1" htmlFor={id}>{field.label}</label>
+      <input id={id} className="border rounded px-2 py-1" {...register(field.key)} />
     </div>
   );
 }

--- a/frontend/src/components/form/runtime/fields/SelectField.tsx
+++ b/frontend/src/components/form/runtime/fields/SelectField.tsx
@@ -1,11 +1,14 @@
+import { useId } from "react";
 import { useFormContext } from "react-hook-form";
 export default function SelectField({ field }:{field:any}) {
   const { register } = useFormContext();
+  const autoId = useId();
+  const id = field.key ?? field.id ?? autoId;
   if (field.type === "multiselect") {
     return (
       <div className="flex flex-col">
-        <label className="mb-1">{field.label}</label>
-        <select multiple className="border rounded px-2 py-1" {...register(field.key)}>
+        <label className="mb-1" htmlFor={id}>{field.label}</label>
+        <select multiple className="border rounded px-2 py-1" id={id} {...register(field.key)}>
           {field.options?.map((o:any)=>(<option key={o.value} value={o.value}>{o.label}</option>))}
         </select>
       </div>
@@ -13,8 +16,8 @@ export default function SelectField({ field }:{field:any}) {
   }
   return (
     <div className="flex flex-col">
-      <label className="mb-1">{field.label}</label>
-      <select className="border rounded px-2 py-1" {...register(field.key)}>
+      <label className="mb-1" htmlFor={id}>{field.label}</label>
+      <select className="border rounded px-2 py-1" id={id} {...register(field.key)}>
         <option value="">{field.placeholder}</option>
         {field.options?.map((o:any)=>(<option key={o.value} value={o.value}>{o.label}</option>))}
       </select>

--- a/frontend/src/components/form/runtime/fields/TextField.tsx
+++ b/frontend/src/components/form/runtime/fields/TextField.tsx
@@ -1,10 +1,13 @@
+import { useId } from "react";
 import { useFormContext } from "react-hook-form";
 export default function TextField({ field }:{field:any}) {
   const { register } = useFormContext();
+  const autoId = useId();
+  const id = field.key ?? field.id ?? autoId;
   return (
     <div className="flex flex-col">
-      <label className="mb-1">{field.label}</label>
-      <input className="border rounded px-2 py-1" {...register(field.key)} placeholder={field.placeholder} />
+      <label className="mb-1" htmlFor={id}>{field.label}</label>
+      <input id={id} className="border rounded px-2 py-1" {...register(field.key)} placeholder={field.placeholder} />
     </div>
   );
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./vitest.setup.ts",
   },
+  esbuild: {
+    jsxInject: "import React from 'react'",
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,2 +1,4 @@
-import "@testing-library/jest-dom";
+import { expect } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
 
+expect.extend(matchers);


### PR DESCRIPTION
## Summary
- expand the frontend README with usage instructions for the template builder, runtime preview and supported components
- add integration-style tests that exercise DynamicForm field rendering and submission success/failure flows
- update runtime field components to wire labels to inputs and configure Vitest to inject React during JSX transforms

## Testing
- npm test -- src/components/form/runtime/DynamicForm.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c897009894832d9d1fb0c6fa2b0e67